### PR TITLE
Build a pinned Boost from source instead of vendoring boost-unordered

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -77,14 +77,11 @@ jobs:
           cmake --version
           mkdir -p build
           cd build
-          # The app bundle ships no headers or libraries, so nothing links
-          # against it and it can use the faster non-default hash map backend.
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.cmakeBuildType }} \
             -DTESTS_ENABLED=ON \
             -DWERROR_ENABLED=ON \
-            -DCOLMAP_HASH_MAP_BACKEND=BOOST \
             -DQt6_DIR="$(brew --prefix qt)/lib/cmake/Qt6"
           ninja
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -149,11 +149,8 @@ jobs:
             # during CUDA compiler detection.
             $env:CUDAFLAGS = "-allow-unsupported-compiler"
           }
-          # The package ships no headers or libraries, so nothing links against
-          # it and it can use the faster non-default hash map backend.
           cmake .. `
             -GNinja `
-            -DCOLMAP_HASH_MAP_BACKEND=BOOST `
             -DCMAKE_MAKE_PROGRAM=ninja `
             -DCMAKE_BUILD_TYPE=Release `
             -DTESTS_ENABLED=${{ matrix.config.testsEnabled }} `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,9 @@ option(BENCHMARK_ENABLED "Whether to enable runtime benchmarking support" OFF)
 option(FETCH_POSELIB "Whether to consume PoseLib using FetchContent or find_package" ON)
 option(FETCH_FAISS "Whether to consume faiss using FetchContent or find_package" ON)
 option(FETCH_ONNX "Whether to consume ONNX using FetchContent or find_package" ON)
-option(FETCH_BOOST "Whether to build a pinned Boost using FetchContent when the available Boost is older than the required version" ON)
+# Unlike the FETCH_* options above, this one is only a fallback: a system Boost
+# that is new enough is always preferred and nothing is downloaded then.
+option(FETCH_BOOST "Whether to fall back to building a pinned Boost using FetchContent if no system Boost of the required version is found" ON)
 option(BUILD_SHARED_LIBS "Whether to build shared libraries (faster linktime, slower runtime)" OFF)
 option(ALL_SOURCE_TARGET "Whether to create a target for all source files (for Visual Studio / XCode development)" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,18 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CMakeHelper.cmake NO_POLICY_SCOPE)
 # COLMAP's static libraries.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# The build type has to be settled before the dependencies are configured. The
+# ones built as subprojects install per-configuration export files, and a
+# subproject configured with an empty CMAKE_BUILD_TYPE installs none, leaving
+# its imported targets without an IMPORTED_LOCATION for consumers.
+if(CMAKE_BUILD_TYPE)
+    message(STATUS "Build type specified as ${CMAKE_BUILD_TYPE}")
+else()
+    message(STATUS "Build type not specified, using Release")
+    set(CMAKE_BUILD_TYPE Release)
+    set(IS_DEBUG OFF)
+endif()
+
 ################################################################################
 # Dependency configuration
 ################################################################################
@@ -149,14 +161,6 @@ include(cmake/FindDependencies.cmake)
 ################################################################################
 # Compiler specific configuration
 ################################################################################
-
-if(CMAKE_BUILD_TYPE)
-    message(STATUS "Build type specified as ${CMAKE_BUILD_TYPE}")
-else()
-    message(STATUS "Build type not specified, using Release")
-    set(CMAKE_BUILD_TYPE Release)
-    set(IS_DEBUG OFF)
-endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "ClangTidy")
     find_program(CLANG_TIDY_EXE NAMES clang-tidy)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ option(BENCHMARK_ENABLED "Whether to enable runtime benchmarking support" OFF)
 option(FETCH_POSELIB "Whether to consume PoseLib using FetchContent or find_package" ON)
 option(FETCH_FAISS "Whether to consume faiss using FetchContent or find_package" ON)
 option(FETCH_ONNX "Whether to consume ONNX using FetchContent or find_package" ON)
-option(FETCH_BOOST_UNORDERED "Whether to consume boost-unordered using FetchContent when the available Boost is older than the required version" ON)
+option(FETCH_BOOST "Whether to build a pinned Boost using FetchContent when the available Boost is older than the required version" ON)
 option(BUILD_SHARED_LIBS "Whether to build shared libraries (faster linktime, slower runtime)" OFF)
 option(ALL_SOURCE_TARGET "Whether to create a target for all source files (for Visual Studio / XCode development)" OFF)
 
@@ -469,9 +469,6 @@ if(GPU_ENABLED)
     list(APPEND COLMAP_EXPORT_LIBS
          colmap_sift_gpu
     )
-endif()
-if(TARGET colmap_boost_unordered)
-    list(APPEND COLMAP_EXPORT_LIBS colmap_boost_unordered)
 endif()
 if(FETCH_POSELIB)
     list(APPEND COLMAP_EXPORT_LIBS PoseLib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,21 +70,13 @@ option(BENCHMARK_ENABLED "Whether to enable runtime benchmarking support" OFF)
 option(FETCH_POSELIB "Whether to consume PoseLib using FetchContent or find_package" ON)
 option(FETCH_FAISS "Whether to consume faiss using FetchContent or find_package" ON)
 option(FETCH_ONNX "Whether to consume ONNX using FetchContent or find_package" ON)
+option(FETCH_BOOST_UNORDERED "Whether to consume boost-unordered using FetchContent when the available Boost is older than the required version" ON)
 option(BUILD_SHARED_LIBS "Whether to build shared libraries (faster linktime, slower runtime)" OFF)
 option(ALL_SOURCE_TARGET "Whether to create a target for all source files (for Visual Studio / XCode development)" OFF)
 
 # Experimental
 option(CASPAR_ENABLED "Whether to enable CASPAR-accelerated bundle adjustment" OFF)
 option(CASPAR_USE_DOUBLE "Use double precision in Caspar solver" OFF)
-
-# Hash map backend used by the performance-critical scene/SfM containers (see
-# src/colmap/util/hash_containers.h). Part of COLMAP's ABI, hence a fixed default
-# rather than one derived from the build machine. BOOST is faster but must be
-# applied to everything loaded alongside COLMAP. AUTO is the old host-dependent
-# selection, kept only for compatibility.
-set(COLMAP_HASH_MAP_BACKEND "" CACHE STRING
-    "Hash map backend for scene/SfM containers: STD, BOOST, or AUTO")
-set_property(CACHE COLMAP_HASH_MAP_BACKEND PROPERTY STRINGS "" STD BOOST AUTO)
 
 if(CASPAR_ENABLED)
     add_compile_definitions(CASPAR_ENABLED)
@@ -477,6 +469,9 @@ if(GPU_ENABLED)
     list(APPEND COLMAP_EXPORT_LIBS
          colmap_sift_gpu
     )
+endif()
+if(TARGET colmap_boost_unordered)
+    list(APPEND COLMAP_EXPORT_LIBS colmap_boost_unordered)
 endif()
 if(FETCH_POSELIB)
     list(APPEND COLMAP_EXPORT_LIBS PoseLib)

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -34,9 +34,16 @@ set(COLMAP_MIN_BOOST_VERSION "1.84.0")
 # find_package(colmap) pre-sets this to what COLMAP was built with, so consumers
 # follow the installed binaries instead of re-deciding from their own Boost.
 if(NOT DEFINED COLMAP_BOOST_FROM_SYSTEM)
-    find_package(Boost QUIET COMPONENTS graph program_options)
-    if(Boost_FOUND AND
-       "${Boost_VERSION_STRING}" VERSION_GREATER_EQUAL "${COLMAP_MIN_BOOST_VERSION}")
+    # The version requirement has to go into the find_package() call rather than
+    # be checked afterwards: a successful find defines the Boost:: imported
+    # targets, and those collide with the ALIAS targets the pinned Boost creates
+    # below. Requesting the minimum version makes a too-old Boost fail the
+    # version check before any target is defined. No COMPONENTS either: a
+    # missing component leaves Boost_FOUND false but still defines the header
+    # targets, so the probe only asks the version question and lets the real
+    # find_package() below report a missing graph or program_options.
+    find_package(Boost ${COLMAP_MIN_BOOST_VERSION} QUIET)
+    if(Boost_FOUND)
         set(COLMAP_BOOST_FROM_SYSTEM TRUE)
     else()
         set(COLMAP_BOOST_FROM_SYSTEM FALSE)

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -50,12 +50,28 @@ if(NOT DEFINED COLMAP_BOOST_FROM_SYSTEM)
     endif()
 endif()
 
+# The header-only Boost libraries COLMAP includes directly. A system Boost has
+# one include directory that Boost::headers already covers, but the CMake-native
+# Boost build keeps every library in its own directory and its own target, so
+# there they have to be named one by one. COLMAP_BOOST_HEADER_LIBS below is what
+# the targets link against.
+set(COLMAP_BOOST_HEADER_COMPONENTS
+    algorithm
+    container_hash
+    heap
+    preprocessor
+    property_map
+    property_tree
+    unordered
+    utility)
+
 if(COLMAP_BOOST_FROM_SYSTEM)
     find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
                  graph
                  program_options
                  OPTIONAL_COMPONENTS
                  system)
+    set(COLMAP_BOOST_HEADER_LIBS Boost::headers)
     if("${Boost_VERSION_STRING}" VERSION_LESS "${COLMAP_MIN_BOOST_VERSION}")
         message(FATAL_ERROR
                 "COLMAP requires Boost >= ${COLMAP_MIN_BOOST_VERSION} for "
@@ -69,7 +85,12 @@ elseif(COLMAP_BOOST_VENDORED_CONFIG_DIR)
     # rather than fetching and building a second copy.
     find_package(Boost ${COLMAP_FIND_TYPE} CONFIG
                  PATHS "${COLMAP_BOOST_VENDORED_CONFIG_DIR}" NO_DEFAULT_PATH
-                 COMPONENTS graph program_options)
+                 COMPONENTS graph program_options
+                            ${COLMAP_BOOST_HEADER_COMPONENTS})
+    set(COLMAP_BOOST_HEADER_LIBS Boost::headers)
+    foreach(_component IN LISTS COLMAP_BOOST_HEADER_COMPONENTS)
+        list(APPEND COLMAP_BOOST_HEADER_LIBS Boost::${_component})
+    endforeach()
     message(STATUS
             "Using Boost vendored by COLMAP at ${COLMAP_BOOST_VENDORED_CONFIG_DIR}")
 elseif(FETCH_BOOST)
@@ -79,16 +100,13 @@ elseif(FETCH_BOOST)
     # the rest of the archive is left alone. Building graph and program_options
     # from source is a few seconds of the total build.
     set(BOOST_INCLUDE_LIBRARIES
-        algorithm
-        container_hash
         graph
-        heap
-        predef
-        preprocessor
         program_options
-        property_map
-        property_tree
-        unordered)
+        ${COLMAP_BOOST_HEADER_COMPONENTS})
+    set(COLMAP_BOOST_HEADER_LIBS Boost::headers)
+    foreach(_component IN LISTS COLMAP_BOOST_HEADER_COMPONENTS)
+        list(APPEND COLMAP_BOOST_HEADER_LIBS Boost::${_component})
+    endforeach()
     set(BOOST_ENABLE_MPI OFF)
     set(BOOST_ENABLE_PYTHON OFF)
     set(BOOST_INSTALL_LAYOUT system)

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -116,10 +116,25 @@ elseif(FETCH_BOOST)
     # leave the headers out of COLMAP's install tree and keep its targets out of
     # any export set, breaking COLMAP's own install(EXPORT).
     set(BOOST_SKIP_INSTALL_RULES OFF)
-    # Boost installs its own package config into COLMAP's prefix; record where,
-    # so colmap-config.cmake can point consumers at the same copy.
+    # Install Boost into a COLMAP-private subdirectory rather than the prefix
+    # root. Installing with the default prefix would otherwise drop Boost 1.92
+    # into /usr/local/include/boost, which precedes /usr/include on the default
+    # search path and would shadow the system Boost for everything else built on
+    # that machine. Boost keys all of its install rules off the three variables
+    # below, so point them at the private directory for the subproject and
+    # restore COLMAP's own values afterwards.
+    set(COLMAP_BOOST_INSTALL_SUBDIR "colmap/thirdparty/boost")
+    set(_colmap_install_includedir "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(_colmap_install_libdir "${CMAKE_INSTALL_LIBDIR}")
+    set(CMAKE_INSTALL_INCLUDEDIR
+        "${_colmap_install_includedir}/${COLMAP_BOOST_INSTALL_SUBDIR}")
+    set(CMAKE_INSTALL_LIBDIR
+        "${_colmap_install_libdir}/${COLMAP_BOOST_INSTALL_SUBDIR}")
+    set(BOOST_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake")
+    # Record where the package config lands, so colmap-config.cmake can point
+    # consumers at the same copy.
     set(COLMAP_BOOST_INSTALL_CMAKEDIR
-        "${CMAKE_INSTALL_LIBDIR}/cmake/Boost-${COLMAP_FETCH_BOOST_VERSION}")
+        "${BOOST_INSTALL_CMAKEDIR}/Boost-${COLMAP_FETCH_BOOST_VERSION}")
     message(STATUS "Configuring Boost ${COLMAP_FETCH_BOOST_VERSION}...")
     FetchContent_Declare(Boost
         URL https://github.com/boostorg/boost/releases/download/boost-${COLMAP_FETCH_BOOST_VERSION}/boost-${COLMAP_FETCH_BOOST_VERSION}-cmake.tar.xz
@@ -127,6 +142,8 @@ elseif(FETCH_BOOST)
         SYSTEM
     )
     FetchContent_MakeAvailable(Boost)
+    set(CMAKE_INSTALL_INCLUDEDIR "${_colmap_install_includedir}")
+    set(CMAKE_INSTALL_LIBDIR "${_colmap_install_libdir}")
     message(STATUS "Configuring Boost ${COLMAP_FETCH_BOOST_VERSION}... done")
 else()
     message(FATAL_ERROR

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -15,57 +15,97 @@ endif()
 
 find_package(OpenMP REQUIRED COMPONENTS C CXX)
 
-find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
-             graph
-             program_options
-             OPTIONAL_COMPONENTS
-             system)
-
 # The scene/SfM containers in src/colmap/util/hash_containers.h are
 # boost::unordered flat/node maps. They are data members of classes in public
 # headers, so their layout is part of COLMAP's ABI and must not depend on the
 # build machine. boost::unordered_node_map requires Boost >= 1.84, which is
-# newer than the apt Boost on Ubuntu 24.04 (1.83) and earlier, so a pinned copy
-# of the header-only boost-unordered modules is vendored where the available
-# Boost is too old (see src/thirdparty/CMakeLists.txt).
-set(COLMAP_MIN_BOOST_UNORDERED_VERSION "1.84.0")
-if(DEFINED Boost_VERSION_STRING AND Boost_VERSION_STRING)
-    set(COLMAP_BOOST_VERSION "${Boost_VERSION_STRING}")
-else()
-    set(COLMAP_BOOST_VERSION "${Boost_VERSION}")
-endif()
+# newer than the apt Boost on Ubuntu 24.04 (1.83) and earlier.
+#
+# Where the system Boost is too old, build a pinned Boost from source rather
+# than vendoring boost-unordered alone. A partial copy has to be placed ahead of
+# the system Boost on the include path to win, which also shadows the support
+# modules it brings with it (core, config, mp11, ...). The rest of the system
+# Boost then compiles against those newer headers -- including Boost.Graph and
+# Boost.ProgramOptions, whose compiled libraries were built against the older
+# ones. Taking all of Boost from one place keeps headers and libraries
+# consistent.
+set(COLMAP_MIN_BOOST_VERSION "1.84.0")
+
 # find_package(colmap) pre-sets this to what COLMAP was built with, so consumers
 # follow the installed binaries instead of re-deciding from their own Boost.
-if(NOT DEFINED COLMAP_BOOST_UNORDERED_FROM_SYSTEM)
-    if(COLMAP_BOOST_VERSION VERSION_GREATER_EQUAL
-       "${COLMAP_MIN_BOOST_UNORDERED_VERSION}")
-        set(COLMAP_BOOST_UNORDERED_FROM_SYSTEM TRUE)
+if(NOT DEFINED COLMAP_BOOST_FROM_SYSTEM)
+    find_package(Boost QUIET COMPONENTS graph program_options)
+    if(Boost_FOUND AND
+       "${Boost_VERSION_STRING}" VERSION_GREATER_EQUAL "${COLMAP_MIN_BOOST_VERSION}")
+        set(COLMAP_BOOST_FROM_SYSTEM TRUE)
     else()
-        set(COLMAP_BOOST_UNORDERED_FROM_SYSTEM FALSE)
+        set(COLMAP_BOOST_FROM_SYSTEM FALSE)
     endif()
 endif()
-if(COLMAP_BOOST_UNORDERED_FROM_SYSTEM)
-    if(COLMAP_BOOST_VERSION VERSION_LESS
-       "${COLMAP_MIN_BOOST_UNORDERED_VERSION}")
+
+if(COLMAP_BOOST_FROM_SYSTEM)
+    find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
+                 graph
+                 program_options
+                 OPTIONAL_COMPONENTS
+                 system)
+    if("${Boost_VERSION_STRING}" VERSION_LESS "${COLMAP_MIN_BOOST_VERSION}")
         message(FATAL_ERROR
-                "COLMAP requires Boost >= ${COLMAP_MIN_BOOST_UNORDERED_VERSION} "
-                "for boost::unordered_node_map, but found Boost "
-                "${COLMAP_BOOST_VERSION}. Upgrade Boost or configure with "
-                "-DFETCH_BOOST_UNORDERED=ON to vendor a pinned copy.")
+                "COLMAP requires Boost >= ${COLMAP_MIN_BOOST_VERSION} for "
+                "boost::unordered_node_map, but found Boost "
+                "${Boost_VERSION_STRING}. Upgrade Boost or configure with "
+                "-DFETCH_BOOST=ON to build a pinned copy from source.")
     endif()
-    message(STATUS "Using boost-unordered from Boost ${COLMAP_BOOST_VERSION}")
-elseif(FETCH_BOOST_UNORDERED)
-    # Vendored headers are installed here and exported as an include directory
-    # of the colmap_boost_unordered target, so consumers of the installed COLMAP
-    # compile its public headers against the same boost-unordered.
-    set(COLMAP_BOOST_UNORDERED_INSTALL_DIR
-        "${CMAKE_INSTALL_INCLUDEDIR}/colmap/thirdparty/boost-unordered")
+    message(STATUS "Using system Boost ${Boost_VERSION_STRING}")
+elseif(COLMAP_BOOST_VENDORED_CONFIG_DIR)
+    # Consumer path: the installed COLMAP shipped its own Boost, so use that one
+    # rather than fetching and building a second copy.
+    find_package(Boost ${COLMAP_FIND_TYPE} CONFIG
+                 PATHS "${COLMAP_BOOST_VENDORED_CONFIG_DIR}" NO_DEFAULT_PATH
+                 COMPONENTS graph program_options)
+    message(STATUS
+            "Using Boost vendored by COLMAP at ${COLMAP_BOOST_VENDORED_CONFIG_DIR}")
+elseif(FETCH_BOOST)
+    include(FetchContent)
+    set(COLMAP_FETCH_BOOST_VERSION "1.92.0")
+    # Only the libraries COLMAP uses, plus their dependencies, are configured;
+    # the rest of the archive is left alone. Building graph and program_options
+    # from source is a few seconds of the total build.
+    set(BOOST_INCLUDE_LIBRARIES
+        algorithm
+        container_hash
+        graph
+        heap
+        predef
+        preprocessor
+        program_options
+        property_map
+        property_tree
+        unordered)
+    set(BOOST_ENABLE_MPI OFF)
+    set(BOOST_ENABLE_PYTHON OFF)
+    set(BOOST_INSTALL_LAYOUT system)
+    # As a subproject Boost skips its install rules by default, which would both
+    # leave the headers out of COLMAP's install tree and keep its targets out of
+    # any export set, breaking COLMAP's own install(EXPORT).
+    set(BOOST_SKIP_INSTALL_RULES OFF)
+    # Boost installs its own package config into COLMAP's prefix; record where,
+    # so colmap-config.cmake can point consumers at the same copy.
+    set(COLMAP_BOOST_INSTALL_CMAKEDIR
+        "${CMAKE_INSTALL_LIBDIR}/cmake/Boost-${COLMAP_FETCH_BOOST_VERSION}")
+    message(STATUS "Configuring Boost ${COLMAP_FETCH_BOOST_VERSION}...")
+    FetchContent_Declare(Boost
+        URL https://github.com/boostorg/boost/releases/download/boost-${COLMAP_FETCH_BOOST_VERSION}/boost-${COLMAP_FETCH_BOOST_VERSION}-cmake.tar.xz
+        URL_HASH SHA256=9bed76128d4e46755dbe818487788c6fceb6f72b378f4daa49b7e1e600d9088d
+        SYSTEM
+    )
+    FetchContent_MakeAvailable(Boost)
+    message(STATUS "Configuring Boost ${COLMAP_FETCH_BOOST_VERSION}... done")
 else()
     message(FATAL_ERROR
-            "Boost ${COLMAP_BOOST_VERSION} is older than "
-            "${COLMAP_MIN_BOOST_UNORDERED_VERSION} and FETCH_BOOST_UNORDERED is "
-            "OFF, so boost::unordered_node_map is unavailable. Upgrade Boost or "
-            "set -DFETCH_BOOST_UNORDERED=ON.")
+            "No Boost >= ${COLMAP_MIN_BOOST_VERSION} was found and FETCH_BOOST "
+            "is OFF, so boost::unordered_node_map is unavailable. Upgrade Boost "
+            "or set -DFETCH_BOOST=ON.")
 endif()
 
 find_package(Eigen3 ${COLMAP_FIND_TYPE})

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -21,56 +21,52 @@ find_package(Boost ${COLMAP_FIND_TYPE} COMPONENTS
              OPTIONAL_COMPONENTS
              system)
 
-# Hash map backend selection for the scene/SfM containers. Adds the compile
-# definition consumed by src/colmap/util/hash_containers.h. Both backends are
-# header-only (boost-unordered is provided by the Boost::boost target), so no
-# extra linking is required.
-#
-# The backend is part of COLMAP's ABI, so the default is fixed rather than
-# derived from the Boost installed here. BOOST (faster, requires Boost >= 1.84
-# for boost::unordered_node_map) must be applied to everything in the process.
-# find_package(colmap) pre-sets the value COLMAP was built with, so the selection
-# below reproduces that choice instead of re-deriving it.
-set(COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION "1.84.0")
+# The scene/SfM containers in src/colmap/util/hash_containers.h are
+# boost::unordered flat/node maps. They are data members of classes in public
+# headers, so their layout is part of COLMAP's ABI and must not depend on the
+# build machine. boost::unordered_node_map requires Boost >= 1.84, which is
+# newer than the apt Boost on Ubuntu 24.04 (1.83) and earlier, so a pinned copy
+# of the header-only boost-unordered modules is vendored where the available
+# Boost is too old (see src/thirdparty/CMakeLists.txt).
+set(COLMAP_MIN_BOOST_UNORDERED_VERSION "1.84.0")
 if(DEFINED Boost_VERSION_STRING AND Boost_VERSION_STRING)
-    set(_colmap_boost_version "${Boost_VERSION_STRING}")
+    set(COLMAP_BOOST_VERSION "${Boost_VERSION_STRING}")
 else()
-    set(_colmap_boost_version "${Boost_VERSION}")
+    set(COLMAP_BOOST_VERSION "${Boost_VERSION}")
 endif()
-string(TOUPPER "${COLMAP_HASH_MAP_BACKEND}" COLMAP_HASH_MAP_BACKEND)
-if(NOT COLMAP_HASH_MAP_BACKEND)
-    set(COLMAP_HASH_MAP_BACKEND "STD")
-elseif(COLMAP_HASH_MAP_BACKEND STREQUAL "AUTO")
-    if(_colmap_boost_version VERSION_GREATER_EQUAL
-       "${COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION}")
-        set(COLMAP_HASH_MAP_BACKEND "BOOST")
+# find_package(colmap) pre-sets this to what COLMAP was built with, so consumers
+# follow the installed binaries instead of re-deciding from their own Boost.
+if(NOT DEFINED COLMAP_BOOST_UNORDERED_FROM_SYSTEM)
+    if(COLMAP_BOOST_VERSION VERSION_GREATER_EQUAL
+       "${COLMAP_MIN_BOOST_UNORDERED_VERSION}")
+        set(COLMAP_BOOST_UNORDERED_FROM_SYSTEM TRUE)
     else()
-        set(COLMAP_HASH_MAP_BACKEND "STD")
+        set(COLMAP_BOOST_UNORDERED_FROM_SYSTEM FALSE)
     endif()
-    message(WARNING
-            "COLMAP_HASH_MAP_BACKEND=AUTO selected ${COLMAP_HASH_MAP_BACKEND} "
-            "from Boost ${_colmap_boost_version}, making the ABI depend on the "
-            "build machine. Pass STD or BOOST for a reproducible ABI.")
 endif()
-if(COLMAP_HASH_MAP_BACKEND STREQUAL "STD")
-    list(APPEND COLMAP_COMPILE_DEFINITIONS COLMAP_HASH_STD)
-elseif(COLMAP_HASH_MAP_BACKEND STREQUAL "BOOST")
-    if(_colmap_boost_version VERSION_LESS
-       "${COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION}")
+if(COLMAP_BOOST_UNORDERED_FROM_SYSTEM)
+    if(COLMAP_BOOST_VERSION VERSION_LESS
+       "${COLMAP_MIN_BOOST_UNORDERED_VERSION}")
         message(FATAL_ERROR
-                "COLMAP_HASH_MAP_BACKEND=BOOST requires Boost >= "
-                "${COLMAP_HASH_MAP_BACKEND_MIN_BOOST_VERSION} "
-                "(boost::unordered_node_map), but found Boost "
-                "${_colmap_boost_version}. Upgrade Boost or set "
-                "-DCOLMAP_HASH_MAP_BACKEND=STD.")
+                "COLMAP requires Boost >= ${COLMAP_MIN_BOOST_UNORDERED_VERSION} "
+                "for boost::unordered_node_map, but found Boost "
+                "${COLMAP_BOOST_VERSION}. Upgrade Boost or configure with "
+                "-DFETCH_BOOST_UNORDERED=ON to vendor a pinned copy.")
     endif()
-    list(APPEND COLMAP_COMPILE_DEFINITIONS COLMAP_HASH_BOOST)
+    message(STATUS "Using boost-unordered from Boost ${COLMAP_BOOST_VERSION}")
+elseif(FETCH_BOOST_UNORDERED)
+    # Vendored headers are installed here and exported as an include directory
+    # of the colmap_boost_unordered target, so consumers of the installed COLMAP
+    # compile its public headers against the same boost-unordered.
+    set(COLMAP_BOOST_UNORDERED_INSTALL_DIR
+        "${CMAKE_INSTALL_INCLUDEDIR}/colmap/thirdparty/boost-unordered")
 else()
-    message(FATAL_ERROR "Unknown COLMAP_HASH_MAP_BACKEND "
-            "'${COLMAP_HASH_MAP_BACKEND}' (expected STD, BOOST, AUTO or empty)")
+    message(FATAL_ERROR
+            "Boost ${COLMAP_BOOST_VERSION} is older than "
+            "${COLMAP_MIN_BOOST_UNORDERED_VERSION} and FETCH_BOOST_UNORDERED is "
+            "OFF, so boost::unordered_node_map is unavailable. Upgrade Boost or "
+            "set -DFETCH_BOOST_UNORDERED=ON.")
 endif()
-message(STATUS "Using ${COLMAP_HASH_MAP_BACKEND} hash map backend "
-        "(Boost ${_colmap_boost_version})")
 
 find_package(Eigen3 ${COLMAP_FIND_TYPE})
 

--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -94,6 +94,8 @@ elseif(COLMAP_BOOST_VENDORED_CONFIG_DIR)
     message(STATUS
             "Using Boost vendored by COLMAP at ${COLMAP_BOOST_VENDORED_CONFIG_DIR}")
 elseif(FETCH_BOOST)
+    # Fallback only, reached when the probe above found no system Boost of the
+    # required version. FETCH_BOOST being ON does not by itself download Boost.
     include(FetchContent)
     set(COLMAP_FETCH_BOOST_VERSION "1.92.0")
     # Only the libraries COLMAP uses, plus their dependencies, are configured;

--- a/cmake/colmap-config.cmake.in
+++ b/cmake/colmap-config.cmake.in
@@ -87,15 +87,20 @@ set(FETCH_POSELIB @FETCH_POSELIB@)
 
 set(FETCH_FAISS @FETCH_FAISS@)
 
-set(FETCH_BOOST_UNORDERED @FETCH_BOOST_UNORDERED@)
+set(FETCH_BOOST @FETCH_BOOST@)
 
-# Where the installed COLMAP got boost-unordered from. Pre-setting this makes
-# FindDependencies.cmake below follow the installed binaries: if COLMAP vendored
-# the headers, the consumer picks them up from the exported
-# colmap_boost_unordered target regardless of its own Boost; if COLMAP used the
-# system Boost, the consumer's Boost has to be new enough too, and gets a
-# configure-time error rather than a silently different container layout.
-set(COLMAP_BOOST_UNORDERED_FROM_SYSTEM @COLMAP_BOOST_UNORDERED_FROM_SYSTEM@)
+# Where the installed COLMAP got Boost from. Pre-setting this makes
+# FindDependencies.cmake below follow the installed binaries: if COLMAP built a
+# pinned Boost, that copy was installed alongside COLMAP and the consumer is
+# pointed at it; if COLMAP used the system Boost, the consumer's Boost has to be
+# new enough too, and gets a configure-time error rather than a silently
+# different container layout.
+set(COLMAP_BOOST_FROM_SYSTEM @COLMAP_BOOST_FROM_SYSTEM@)
+if(NOT COLMAP_BOOST_FROM_SYSTEM)
+    # The vendored Boost installed its own package config into COLMAP's prefix.
+    set(COLMAP_BOOST_VENDORED_CONFIG_DIR
+        "${PACKAGE_PREFIX_DIR}/@COLMAP_BOOST_INSTALL_CMAKEDIR@")
+endif()
 
 set(FETCH_ONNX FALSE)
 if(@FETCH_ONNX@)
@@ -106,8 +111,11 @@ if(@FETCH_ONNX@)
     set(onnxruntime_LIBRARY_DIR_HINTS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@ CACHE PATH "ONNX Runtime library directory hints")
 endif()
 
-include(${PACKAGE_PREFIX_DIR}/share/colmap/colmap-targets.cmake)
+# Dependencies first: a vendored Boost is exported from its own export set
+# rather than imported, so colmap-targets.cmake checks that those targets
+# already exist and fails the whole package if they do not.
 include(${PACKAGE_PREFIX_DIR}/share/colmap/cmake/FindDependencies.cmake)
+include(${PACKAGE_PREFIX_DIR}/share/colmap/colmap-targets.cmake)
 check_required_components(colmap)
 
 # Reset to previous value

--- a/cmake/colmap-config.cmake.in
+++ b/cmake/colmap-config.cmake.in
@@ -87,18 +87,15 @@ set(FETCH_POSELIB @FETCH_POSELIB@)
 
 set(FETCH_FAISS @FETCH_FAISS@)
 
-# Backend COLMAP was built with. Pre-setting it makes FindDependencies.cmake
-# below follow the installed binaries instead of the consumer's Boost.
-string(TOUPPER "${COLMAP_HASH_MAP_BACKEND}" _colmap_requested_hash_map_backend)
-if(_colmap_requested_hash_map_backend AND
-   NOT _colmap_requested_hash_map_backend STREQUAL "@COLMAP_HASH_MAP_BACKEND@")
-    message(WARNING
-            "Ignoring COLMAP_HASH_MAP_BACKEND="
-            "${_colmap_requested_hash_map_backend}: the installed COLMAP was "
-            "built with @COLMAP_HASH_MAP_BACKEND@.")
-endif()
-unset(_colmap_requested_hash_map_backend)
-set(COLMAP_HASH_MAP_BACKEND "@COLMAP_HASH_MAP_BACKEND@")
+set(FETCH_BOOST_UNORDERED @FETCH_BOOST_UNORDERED@)
+
+# Where the installed COLMAP got boost-unordered from. Pre-setting this makes
+# FindDependencies.cmake below follow the installed binaries: if COLMAP vendored
+# the headers, the consumer picks them up from the exported
+# colmap_boost_unordered target regardless of its own Boost; if COLMAP used the
+# system Boost, the consumer's Boost has to be new enough too, and gets a
+# configure-time error rather than a silently different container layout.
+set(COLMAP_BOOST_UNORDERED_FROM_SYSTEM @COLMAP_BOOST_UNORDERED_FROM_SYSTEM@)
 
 set(FETCH_ONNX FALSE)
 if(@FETCH_ONNX@)

--- a/cmake/colmap-config.cmake.in
+++ b/cmake/colmap-config.cmake.in
@@ -113,9 +113,12 @@ endif()
 
 # Dependencies first: a vendored Boost is exported from its own export set
 # rather than imported, so colmap-targets.cmake checks that those targets
-# already exist and fails the whole package if they do not.
-include(${PACKAGE_PREFIX_DIR}/share/colmap/cmake/FindDependencies.cmake)
-include(${PACKAGE_PREFIX_DIR}/share/colmap/colmap-targets.cmake)
+# already exist and fails the whole package if they do not. The dependency
+# configs run their own @PACKAGE_INIT@ and overwrite PACKAGE_PREFIX_DIR with
+# their prefix, so remember COLMAP's before including them.
+set(COLMAP_PACKAGE_PREFIX_DIR ${PACKAGE_PREFIX_DIR})
+include(${COLMAP_PACKAGE_PREFIX_DIR}/share/colmap/cmake/FindDependencies.cmake)
+include(${COLMAP_PACKAGE_PREFIX_DIR}/share/colmap/colmap-targets.cmake)
 check_required_components(colmap)
 
 # Reset to previous value

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -171,8 +171,9 @@ Configure and compile COLMAP::
 
     ``boost::unordered_node_map`` requires **Boost >= 1.84**, which is newer than
     the apt Boost on Ubuntu 24.04 (1.83) and earlier. Where the available Boost
-    is too old, the build downloads a pinned Boost release (about 100 MB) and
-    builds the libraries COLMAP uses from source, installing them alongside
+    is new enough it is used as it is and nothing is downloaded. Only where it
+    is too old does the build download a pinned Boost release (about 100 MB) and
+    build the libraries COLMAP uses from source, installing them alongside
     COLMAP. Only Boost is taken from that copy, so its headers and compiled
     libraries always match. Pass ``-DFETCH_BOOST=OFF`` to require a new enough
     system Boost instead and fail at configure time if there is none.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -171,9 +171,10 @@ Configure and compile COLMAP::
 
     ``boost::unordered_node_map`` requires **Boost >= 1.84**, which is newer than
     the apt Boost on Ubuntu 24.04 (1.83) and earlier. Where the available Boost
-    is too old, the build downloads a pinned copy of the header-only
-    ``boost-unordered`` modules (about 5 MB) and installs them alongside COLMAP's
-    own headers. Pass ``-DFETCH_BOOST_UNORDERED=OFF`` to require a new enough
+    is too old, the build downloads a pinned Boost release (about 100 MB) and
+    builds the libraries COLMAP uses from source, installing them alongside
+    COLMAP. Only Boost is taken from that copy, so its headers and compiled
+    libraries always match. Pass ``-DFETCH_BOOST=OFF`` to require a new enough
     system Boost instead and fail at configure time if there is none.
 
 Run COLMAP::

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -162,25 +162,19 @@ Configure and compile COLMAP::
 
 .. note::
 
-    COLMAP can use ``boost::unordered`` flat/node hash maps for the
-    performance-critical scene and SfM containers, selected via
-    ``-DCOLMAP_HASH_MAP_BACKEND=STD|BOOST`` (default: ``STD``). ``BOOST`` is
-    faster but requires **Boost >= 1.84** for ``boost::unordered_node_map``;
-    requesting it with an older Boost, such as the apt Boost on Ubuntu 24.04
-    (1.83) and earlier, is a configuration error. vcpkg installs a new enough
-    ``boost-unordered``.
+    COLMAP uses ``boost::unordered`` flat/node hash maps for the
+    performance-critical scene and SfM containers. These are data members of
+    classes in public headers, so their layout is part of COLMAP's ABI, and a
+    mismatch between two COLMAP builds loaded into one process produces no link
+    error, only memory corruption. There is therefore no build option to swap
+    them for ``std::unordered_*``.
 
-    **The backend is part of COLMAP's ABI.** These containers are data members of
-    classes in public headers, so ``sizeof(Reconstruction)`` is 320 bytes with
-    ``STD`` and 280 with ``BOOST`` on x86-64 Linux, and a mismatch produces no
-    link error, only memory corruption. Every binary sharing COLMAP types in one
-    process must agree, including the prebuilt ``pycolmap`` wheels, which use the
-    default. Query a build with ``colmap -h``, ``pycolmap.__hash_map_backend__``
-    or ``colmap::kHashMapBackend``.
-
-    ``AUTO`` picks the backend from the available Boost version, as older COLMAP
-    releases did. Avoid it: two machines then build different ABIs from the same
-    source and arguments.
+    ``boost::unordered_node_map`` requires **Boost >= 1.84**, which is newer than
+    the apt Boost on Ubuntu 24.04 (1.83) and earlier. Where the available Boost
+    is too old, the build downloads a pinned copy of the header-only
+    ``boost-unordered`` modules (about 5 MB) and installs them alongside COLMAP's
+    own headers. Pass ``-DFETCH_BOOST_UNORDERED=OFF`` to require a new enough
+    system Boost instead and fail at configure time if there is none.
 
 Run COLMAP::
 

--- a/python/pycolmap/__init__.py
+++ b/python/pycolmap/__init__.py
@@ -66,8 +66,7 @@ if TYPE_CHECKING:
 __all__ = import_module_symbols(
     globals(), _core, exclude={"cost_functions", "pyceres"}
 )
-__all__.extend(["__version__", "__ceres_version__", "__hash_map_backend__"])
+__all__.extend(["__version__", "__ceres_version__"])
 
 __version__ = _core.__version__
 __ceres_version__ = _core.__ceres_version__
-__hash_map_backend__ = _core.__hash_map_backend__

--- a/src/colmap/controllers/CMakeLists.txt
+++ b/src/colmap/controllers/CMakeLists.txt
@@ -63,7 +63,7 @@ COLMAP_ADD_LIBRARY(
         colmap_math
         colmap_sfm
         Ceres::ceres
-        Boost::boost
+        ${COLMAP_BOOST_HEADER_LIBS}
         faiss
 )
 if(MVS_ENABLED)

--- a/src/colmap/exe/CMakeLists.txt
+++ b/src/colmap/exe/CMakeLists.txt
@@ -80,7 +80,7 @@ COLMAP_ADD_LIBRARY(
     PUBLIC_LINK_LIBS
         ${COLMAP_EXE_PUBLIC_LIBS}
     PRIVATE_LINK_LIBS
-        Boost::boost
+        ${COLMAP_BOOST_HEADER_LIBS}
         colmap_sfm
 )
 
@@ -121,7 +121,7 @@ COLMAP_ADD_EXECUTABLE(
         colmap_sfm
         colmap_util
         ${OPTIONAL_LIBS}
-        Boost::boost
+        ${COLMAP_BOOST_HEADER_LIBS}
 )
 if(HIP_ENABLED)
     target_link_libraries(colmap_main hip::host hip::hiprand roc::rocrand)

--- a/src/colmap/math/CMakeLists.txt
+++ b/src/colmap/math/CMakeLists.txt
@@ -47,7 +47,7 @@ COLMAP_ADD_LIBRARY(
         Boost::graph
         Eigen3::Eigen
     PRIVATE_LINK_LIBS
-        Boost::boost
+        ${COLMAP_BOOST_HEADER_LIBS}
         metis
 )
 

--- a/src/colmap/mvs/texture_mapping.cc
+++ b/src/colmap/mvs/texture_mapping.cc
@@ -47,6 +47,10 @@
 
 #if defined(COLMAP_CGAL_ENABLED)
 #include <CGAL/version.h>
+// Older CGAL releases use boost::prior without including its header and rely
+// on another Boost header pulling it in. That no longer happens with the Boost
+// COLMAP pins, so include it here, ahead of the CGAL headers that need it.
+#include <boost/next_prior.hpp>
 #if CGAL_VERSION_MAJOR >= 6
 #include <CGAL/AABB_traits_3.h>
 #include <CGAL/AABB_triangle_primitive_3.h>

--- a/src/colmap/retrieval/CMakeLists.txt
+++ b/src/colmap/retrieval/CMakeLists.txt
@@ -45,7 +45,7 @@ COLMAP_ADD_LIBRARY(
         colmap_util
         colmap_math
         colmap_feature_types
-        Boost::boost
+        ${COLMAP_BOOST_HEADER_LIBS}
         Eigen3::Eigen
     PRIVATE_LINK_LIBS
         colmap_estimators

--- a/src/colmap/scene/database_cache.cc
+++ b/src/colmap/scene/database_cache.cc
@@ -425,24 +425,33 @@ std::shared_ptr<DatabaseCache> DatabaseCache::CreateFromCache(
   return cache;
 }
 
+// The Add* members below take their argument by value and move it into the
+// container. clang-tidy does not recognize the move through the variadic
+// emplace of boost::unordered and reports the parameter as an unnecessary
+// copy, so performance-unnecessary-value-param is suppressed for each of them.
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void DatabaseCache::AddRig(class Rig rig) {
   const rig_t rig_id = rig.RigId();
   THROW_CHECK(!ExistsRig(rig_id));
   rigs_.emplace(rig_id, std::move(rig));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void DatabaseCache::AddCamera(struct Camera camera) {
   const camera_t camera_id = camera.camera_id;
   THROW_CHECK(!ExistsCamera(camera_id));
   cameras_.emplace(camera_id, std::move(camera));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void DatabaseCache::AddFrame(class Frame frame) {
   const rig_t frame_id = frame.FrameId();
   THROW_CHECK(!ExistsFrame(frame_id));
   frames_.emplace(frame_id, std::move(frame));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void DatabaseCache::AddImage(class Image image) {
   const image_t image_id = image.ImageId();
   THROW_CHECK(!ExistsImage(image_id));

--- a/src/colmap/scene/reconstruction.cc
+++ b/src/colmap/scene/reconstruction.cc
@@ -418,6 +418,9 @@ void Reconstruction::AddRig(class Rig rig) {
   THROW_CHECK(rigs_.emplace(rig_id, std::move(rig)).second);
 }
 
+// Taken by value and moved into cameras_; clang-tidy does not recognize the
+// move through the variadic emplace of boost::unordered.
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void Reconstruction::AddCamera(struct Camera camera) {
   const camera_t camera_id = camera.camera_id;
   THROW_CHECK(camera.VerifyParams());

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -57,7 +57,7 @@ COLMAP_ADD_LIBRARY(
     PUBLIC_LINK_LIBS
         Eigen3::Eigen
         glog::glog
-        Boost::boost
+        ${COLMAP_BOOST_HEADER_LIBS}
         OpenImageIO::OpenImageIO
     PRIVATE_LINK_LIBS
         $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -62,6 +62,17 @@ COLMAP_ADD_LIBRARY(
     PRIVATE_LINK_LIBS
         $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>
 )
+if(TARGET colmap_boost_unordered)
+    # hash_containers.h is a public header, so the vendored boost-unordered has
+    # to reach every consumer of colmap_util. BEFORE puts it ahead of the system
+    # Boost include directory, which may hold an older boost/unordered.
+    target_link_libraries(colmap_util PUBLIC colmap_boost_unordered)
+    get_target_property(_boost_unordered_includes colmap_boost_unordered
+                        INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(colmap_util SYSTEM BEFORE PUBLIC
+                               ${_boost_unordered_includes})
+endif()
+
 if(DOWNLOAD_ENABLED)
     target_link_libraries(colmap_util PRIVATE CURL::libcurl)
     if(TARGET cryptopp::cryptopp)

--- a/src/colmap/util/CMakeLists.txt
+++ b/src/colmap/util/CMakeLists.txt
@@ -62,17 +62,6 @@ COLMAP_ADD_LIBRARY(
     PRIVATE_LINK_LIBS
         $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>
 )
-if(TARGET colmap_boost_unordered)
-    # hash_containers.h is a public header, so the vendored boost-unordered has
-    # to reach every consumer of colmap_util. BEFORE puts it ahead of the system
-    # Boost include directory, which may hold an older boost/unordered.
-    target_link_libraries(colmap_util PUBLIC colmap_boost_unordered)
-    get_target_property(_boost_unordered_includes colmap_boost_unordered
-                        INTERFACE_INCLUDE_DIRECTORIES)
-    target_include_directories(colmap_util SYSTEM BEFORE PUBLIC
-                               ${_boost_unordered_includes})
-endif()
-
 if(DOWNLOAD_ENABLED)
     target_link_libraries(colmap_util PRIVATE CURL::libcurl)
     if(TARGET cryptopp::cryptopp)

--- a/src/colmap/util/hash_containers.h
+++ b/src/colmap/util/hash_containers.h
@@ -29,26 +29,21 @@
 
 #pragma once
 
-// Backend-selectable hash container aliases for COLMAP.
+// Hash container aliases for COLMAP.
 //
 // This header centralizes the hash map/set implementation used across the
-// performance-critical scene and SfM data structures so that the underlying
-// container can be swapped at compile time, without touching call sites. The
-// backend is selected by one of the following macros, set by CMake via the
-// COLMAP_HASH_MAP_BACKEND cache variable:
-//
-//   COLMAP_HASH_STD    -> std::unordered_map / std::unordered_set (default)
-//   COLMAP_HASH_BOOST  -> boost::unordered_flat_* / boost::unordered_node_*
+// performance-critical scene and SfM data structures, so that the underlying
+// container can be swapped without touching call sites.
 //
 // Two families of aliases are provided:
 //
 //   FlatHashMap / FlatHashSet
 //       Open-addressing (flat) containers. Fastest and lowest-memory, but they
 //       INVALIDATE references, pointers, and iterators to elements on any
-//       insertion that triggers a rehash (and, for boost, on erase). Use only
-//       where no long-lived reference to a stored element is held across a
-//       mutation of the same container, and avoid iterator-based erase loops
-//       (erase by key instead).
+//       insertion that triggers a rehash, and on erase. Use only where no
+//       long-lived reference to a stored element is held across a mutation of
+//       the same container, and avoid iterator-based erase loops (erase by key
+//       instead).
 //
 //   NodeHashMap / NodeHashSet
 //       Node-based containers whose element references/pointers remain valid
@@ -56,38 +51,25 @@
 //       Use as the drop-in replacement for element stores that may hand out
 //       long-lived references.
 //
-// The default hash is std::hash<K> for both backends, so the existing custom
-// std::hash specializations and colmap::PairHash (see util/types.h) are reused
-// unchanged and the hashing semantics are held constant across backends.
-// boost::unordered internally re-mixes a non-avalanching hash such as the
-// identity std::hash<uint32_t>.
+// The default hash is std::hash<K>, so the custom std::hash specializations and
+// colmap::PairHash (see util/types.h) are reused unchanged. boost::unordered
+// internally re-mixes a non-avalanching hash such as the identity
+// std::hash<uint32_t>.
 //
-// WARNING: these aliases are data members of classes in public headers, so the
-// backend changes their layout. Nothing about the choice reaches the linker, so
-// mixing backends corrupts memory instead of failing to link.
+// These aliases are data members of classes in public headers, so their layout
+// is part of COLMAP's ABI, and nothing about it reaches the linker. There is
+// deliberately no build option to swap them: two COLMAP builds that disagreed
+// would corrupt memory when loaded into one process instead of failing to link.
+// boost::unordered_node_map requires Boost >= 1.84; see FETCH_BOOST_UNORDERED
+// in cmake/FindDependencies.cmake for how that is guaranteed.
 
-#include <functional>
-
-#if defined(COLMAP_HASH_BOOST)
 #include <boost/unordered/unordered_flat_map.hpp>
 #include <boost/unordered/unordered_flat_set.hpp>
 #include <boost/unordered/unordered_node_map.hpp>
 #include <boost/unordered/unordered_node_set.hpp>
-#else
-// Default to the standard library when no backend macro is defined.
-#ifndef COLMAP_HASH_STD
-#define COLMAP_HASH_STD
-#endif
-#include <unordered_map>
-#include <unordered_set>
-#endif
+#include <functional>
 
 namespace colmap {
-
-#if defined(COLMAP_HASH_BOOST)
-
-// Identifies the layout of every class storing these containers.
-inline constexpr const char* kHashMapBackend = "boost";
 
 template <class Key,
           class Value,
@@ -106,29 +88,5 @@ using NodeHashMap = boost::unordered_node_map<Key, Value, Hash, Eq>;
 
 template <class Key, class Hash = std::hash<Key>, class Eq = std::equal_to<Key>>
 using NodeHashSet = boost::unordered_node_set<Key, Hash, Eq>;
-
-#else  // COLMAP_HASH_STD
-
-inline constexpr const char* kHashMapBackend = "std";
-
-template <class Key,
-          class Value,
-          class Hash = std::hash<Key>,
-          class Eq = std::equal_to<Key>>
-using FlatHashMap = std::unordered_map<Key, Value, Hash, Eq>;
-
-template <class Key, class Hash = std::hash<Key>, class Eq = std::equal_to<Key>>
-using FlatHashSet = std::unordered_set<Key, Hash, Eq>;
-
-template <class Key,
-          class Value,
-          class Hash = std::hash<Key>,
-          class Eq = std::equal_to<Key>>
-using NodeHashMap = std::unordered_map<Key, Value, Hash, Eq>;
-
-template <class Key, class Hash = std::hash<Key>, class Eq = std::equal_to<Key>>
-using NodeHashSet = std::unordered_set<Key, Hash, Eq>;
-
-#endif
 
 }  // namespace colmap

--- a/src/colmap/util/hash_containers.h
+++ b/src/colmap/util/hash_containers.h
@@ -63,11 +63,12 @@
 // boost::unordered_node_map requires Boost >= 1.84; see FETCH_BOOST_UNORDERED
 // in cmake/FindDependencies.cmake for how that is guaranteed.
 
+#include <functional>
+
 #include <boost/unordered/unordered_flat_map.hpp>
 #include <boost/unordered/unordered_flat_set.hpp>
 #include <boost/unordered/unordered_node_map.hpp>
 #include <boost/unordered/unordered_node_set.hpp>
-#include <functional>
 
 namespace colmap {
 

--- a/src/colmap/util/hash_containers.h
+++ b/src/colmap/util/hash_containers.h
@@ -60,8 +60,8 @@
 // is part of COLMAP's ABI, and nothing about it reaches the linker. There is
 // deliberately no build option to swap them: two COLMAP builds that disagreed
 // would corrupt memory when loaded into one process instead of failing to link.
-// boost::unordered_node_map requires Boost >= 1.84; see FETCH_BOOST_UNORDERED
-// in cmake/FindDependencies.cmake for how that is guaranteed.
+// boost::unordered_node_map requires Boost >= 1.84; see FETCH_BOOST in
+// cmake/FindDependencies.cmake for how that is guaranteed.
 
 #include <functional>
 

--- a/src/colmap/util/version.cc.in
+++ b/src/colmap/util/version.cc.in
@@ -30,7 +30,6 @@
 
 #include "colmap/util/version.h"
 
-#include "colmap/util/hash_containers.h"
 #include "colmap/util/logging.h"
 #include "colmap/util/string.h"
 
@@ -74,13 +73,10 @@ std::string GetBuildInfo() {
 #else
   const char* gpu_info = "without GPU support";
 #endif
-  // The hash map backend is part of the ABI, and otherwise indistinguishable
-  // between two builds of the same commit.
-  return StringPrintf("Commit %s on %s %s, %s hash maps",
+  return StringPrintf("Commit %s on %s %s",
                       COLMAP_COMMIT_ID,
                       COLMAP_COMMIT_DATE,
-                      gpu_info,
-                      kHashMapBackend);
+                      gpu_info);
 }
 
 }  // namespace colmap

--- a/src/pycolmap/main.cc
+++ b/src/pycolmap/main.cc
@@ -43,11 +43,6 @@ PYBIND11_MODULE(_core, m) {
   m.attr("has_cuda") = IsGPU(Device::AUTO);
   m.attr("COLMAP_version") = py::str(GetVersionInfo());
   m.attr("COLMAP_build") = py::str(GetBuildInfo());
-  // An extension linking its own COLMAP must share this backend, or the two
-  // disagree about the layout of Reconstruction and friends. Neither the link
-  // nor the import catches that, so expose it for downstreams to assert on.
-  m.attr("__hash_map_backend__") = py::str(kHashMapBackend);
-
   auto PyDevice = py::enum_<Device>(m, "Device")
                       .value("auto", Device::AUTO)
                       .value("cpu", Device::CPU)

--- a/src/pycolmap/main_test.py
+++ b/src/pycolmap/main_test.py
@@ -11,10 +11,6 @@ def test_ceres_version_is_str() -> None:
     assert len(pycolmap.__ceres_version__) > 0
 
 
-def test_hash_map_backend_is_known() -> None:
-    assert pycolmap.__hash_map_backend__ in ("std", "boost")
-
-
 def test_has_cuda_is_bool() -> None:
     assert isinstance(pycolmap.has_cuda, bool)
 

--- a/src/pycolmap/pybind11_extension.h
+++ b/src/pycolmap/pybind11_extension.h
@@ -151,13 +151,10 @@ struct type_caster<std::vector<Eigen::Matrix<Scalar, Size, 1>>> {
 // pybind11's built-in STL casters only recognize std:: containers, so provide
 // casters for the colmap flat hash aliases used across the bindings (e.g.
 // ObservationManager::ImagePairs, IncrementalMapper::FilteredFrames,
-// BundleAdjustmentConfig::VariablePoints, the FilterPoints3D* parameters). Only
-// needed for the BOOST backend; for STD the aliases are std:: types pybind11
-// already handles. Flat containers are never PYBIND11_MAKE_OPAQUE, so these
-// generic casters cannot collide with opaque bound types. (The NodeHashMap
-// caster lives in pycolmap/scene/types.h next to the opaque element-store
-// maps.)
-#if defined(COLMAP_HASH_BOOST)
+// BundleAdjustmentConfig::VariablePoints, the FilterPoints3D* parameters). Flat
+// containers are never PYBIND11_MAKE_OPAQUE, so these generic casters cannot
+// collide with opaque bound types. (The NodeHashMap caster lives in
+// pycolmap/scene/types.h next to the opaque element-store maps.)
 template <typename Key, typename Value, typename Hash, typename Equal>
 struct type_caster<colmap::FlatHashMap<Key, Value, Hash, Equal>>
     : map_caster<colmap::FlatHashMap<Key, Value, Hash, Equal>, Key, Value> {};
@@ -165,7 +162,6 @@ struct type_caster<colmap::FlatHashMap<Key, Value, Hash, Equal>>
 template <typename Key, typename Hash, typename Equal>
 struct type_caster<colmap::FlatHashSet<Key, Hash, Equal>>
     : set_caster<colmap::FlatHashSet<Key, Hash, Equal>, Key> {};
-#endif
 
 }  // namespace detail
 

--- a/src/pycolmap/scene/types.h
+++ b/src/pycolmap/scene/types.h
@@ -42,13 +42,11 @@ using PoseGraphEdgeMap =
 PYBIND11_MAKE_OPAQUE(PoseGraphEdgeMap);
 
 // Generic caster for non-opaque NodeHashMap returns (e.g.
-// CorrespondenceGraph::NumMatchesBetweenAllImages). Only needed for the BOOST
-// backend; for STD the alias is std::unordered_map, handled by pybind11. Kept
+// CorrespondenceGraph::NumMatchesBetweenAllImages). Kept
 // here next to the PYBIND11_MAKE_OPAQUE element-store aliases above so that the
 // opaque full specializations always take precedence over this partial one (the
 // flat casters, which never collide with opaque types, live in
 // pycolmap/pybind11_extension.h). Requires <pybind11/stl.h> for map_caster.
-#if defined(COLMAP_HASH_BOOST)
 namespace pybind11 {
 namespace detail {
 
@@ -58,4 +56,3 @@ struct type_caster<colmap::NodeHashMap<Key, Value, Hash, Equal>>
 
 }  // namespace detail
 }  // namespace pybind11
-#endif

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -34,59 +34,6 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
     set(_fetch_content_declare_args "SYSTEM" "EXCLUDE_FROM_ALL")
 endif()
 
-# boost::unordered_node_map requires Boost >= 1.84, which is newer than the apt
-# Boost on Ubuntu 24.04 and earlier. The containers are part of COLMAP's ABI
-# (see cmake/FindDependencies.cmake), so rather than falling back to a second
-# container implementation, vendor a pinned copy of the header-only modules that
-# boost-unordered transitively includes. The list is the include closure of
-# boost/unordered/unordered_{flat,node}_{map,set}.hpp, ~5 MB in total.
-if(NOT COLMAP_BOOST_UNORDERED_FROM_SYSTEM AND FETCH_BOOST_UNORDERED)
-    include(FetchContent)
-    set(_boost_unordered_tag "boost-1.92.0")
-    set(_boost_unordered_modules
-        unordered       cc2eac1c597c221f20d166273825bba3581e64b75c295e97eb67bd5444d4bef0
-        assert          8d49fc69df12e8fbc0e7fe3c4ede45044747199ccdeaf66c2aebb146becc54aa
-        config          b4171037f13373203ba79cbc141d612982052283e696a315185ab5bea46102a0
-        container_hash  f88aabbbc2f163db5eea65662b26e5af2bde0a0bff065c645b7347ed6a71a566
-        core            aa4eb2ccbe5577ded70f25b8f0d852a5246591f90cc34916160739e3d0dbfea6
-        describe        4ef61ea2ca967b803e171f4756e03e201680d5dd19d014324f9a848e0d06863b
-        mp11            a5754dc5ff9e7ff34119983889530e3ab8d8fb43ce2b4fea9c18673044df45d9
-        predef          4c870bcf7f547f3e3d1db26700b078a33f87c4c8232cd1c8d89ec82be6b54130
-        throw_exception 1ddbb967a43504e28bbe2a35a010df9f7ff5d1a49d3678c9fdfc035fd32ce005
-    )
-    message(STATUS "Configuring boost-unordered (${_boost_unordered_tag})...")
-    add_library(colmap_boost_unordered INTERFACE)
-    # These headers shadow the same modules in the older system Boost, so the
-    # rest of Boost (property_tree, graph, ...) ends up calling into them. Where
-    # the newer copy has since deprecated a symbol the older callers still use
-    # -- boost::swap in boost/core, called by property_tree -- the diagnostic is
-    # attributed to the instantiation site in COLMAP's own sources rather than
-    # to a system header, so it is not suppressed and -Werror rejects it.
-    target_compile_definitions(colmap_boost_unordered INTERFACE
-        BOOST_ALLOW_DEPRECATED)
-    while(_boost_unordered_modules)
-        list(POP_FRONT _boost_unordered_modules _module _hash)
-        # SOURCE_SUBDIR names a directory without a CMakeLists.txt so that the
-        # module is only downloaded, never add_subdirectory()'d. The per-module
-        # Boost CMake files expect the Boost superproject and would collide with
-        # the Boost:: targets from find_package(Boost).
-        FetchContent_Declare(boost_${_module}
-            URL https://github.com/boostorg/${_module}/archive/refs/tags/${_boost_unordered_tag}.tar.gz
-            URL_HASH SHA256=${_hash}
-            SOURCE_SUBDIR do-not-configure
-            ${_fetch_content_declare_args}
-        )
-        FetchContent_MakeAvailable(boost_${_module})
-        target_include_directories(colmap_boost_unordered SYSTEM INTERFACE
-            $<BUILD_INTERFACE:${boost_${_module}_SOURCE_DIR}/include>)
-        install(DIRECTORY "${boost_${_module}_SOURCE_DIR}/include/boost"
-                DESTINATION "${COLMAP_BOOST_UNORDERED_INSTALL_DIR}")
-    endwhile()
-    target_include_directories(colmap_boost_unordered SYSTEM INTERFACE
-        $<INSTALL_INTERFACE:${COLMAP_BOOST_UNORDERED_INSTALL_DIR}>)
-    message(STATUS "Configuring boost-unordered (${_boost_unordered_tag})... done")
-endif()
-
 if(FETCH_POSELIB)
     include(FetchContent)
     FetchContent_Declare(poselib

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -34,6 +34,52 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
     set(_fetch_content_declare_args "SYSTEM" "EXCLUDE_FROM_ALL")
 endif()
 
+# boost::unordered_node_map requires Boost >= 1.84, which is newer than the apt
+# Boost on Ubuntu 24.04 and earlier. The containers are part of COLMAP's ABI
+# (see cmake/FindDependencies.cmake), so rather than falling back to a second
+# container implementation, vendor a pinned copy of the header-only modules that
+# boost-unordered transitively includes. The list is the include closure of
+# boost/unordered/unordered_{flat,node}_{map,set}.hpp, ~5 MB in total.
+if(NOT COLMAP_BOOST_UNORDERED_FROM_SYSTEM AND FETCH_BOOST_UNORDERED)
+    include(FetchContent)
+    set(_boost_unordered_tag "boost-1.90.0")
+    set(_boost_unordered_modules
+        unordered       7dd15a1196e36de483fc287a5487210b596979761c4708b4c3067a717c765a05
+        assert          1f48f929e69146db222fdf9538ec81c7cbd3ca88b94343644942b477031a3bba
+        config          1390bd79fbf270e40cfe5ac6b899f4a9c4e47139b6e17b4c1f7f78822adaa9fc
+        container_hash  415d6a01b2d8a07ab36dbf9e31a8fec6fa0e51185d1015a087c153de28cfaba5
+        core            0444b7741bcf20f80ff6a4d191a920f6aba92d26734c81fa481f8fd0a274b487
+        describe        4ca9c54d50c5bd8ec68811475ef96ec1ac0abbfbf19f55789823aabcbb704812
+        mp11            ca52bde753586dcba29739cfd55abb473bf80c934c6d49a2b58023ed4e48adf6
+        predef          d9144eb3c7d965991e8798fc7e96d5ea862951bffcbdba0b8a23892fd5c99f7c
+        static_assert   3b7980c5968d585b04f980bbb4e81bbbf0b6d1a0b7c965c2a3426b0acb4a5f49
+        throw_exception 30e2834ba64587a363750e35c627ee045f89be05d0cc9eab7251414eba88e110
+    )
+    message(STATUS "Configuring boost-unordered (${_boost_unordered_tag})...")
+    add_library(colmap_boost_unordered INTERFACE)
+    while(_boost_unordered_modules)
+        list(POP_FRONT _boost_unordered_modules _module _hash)
+        # SOURCE_SUBDIR names a directory without a CMakeLists.txt so that the
+        # module is only downloaded, never add_subdirectory()'d. The per-module
+        # Boost CMake files expect the Boost superproject and would collide with
+        # the Boost:: targets from find_package(Boost).
+        FetchContent_Declare(boost_${_module}
+            URL https://github.com/boostorg/${_module}/archive/refs/tags/${_boost_unordered_tag}.tar.gz
+            URL_HASH SHA256=${_hash}
+            SOURCE_SUBDIR do-not-configure
+            ${_fetch_content_declare_args}
+        )
+        FetchContent_MakeAvailable(boost_${_module})
+        target_include_directories(colmap_boost_unordered SYSTEM INTERFACE
+            $<BUILD_INTERFACE:${boost_${_module}_SOURCE_DIR}/include>)
+        install(DIRECTORY "${boost_${_module}_SOURCE_DIR}/include/boost"
+                DESTINATION "${COLMAP_BOOST_UNORDERED_INSTALL_DIR}")
+    endwhile()
+    target_include_directories(colmap_boost_unordered SYSTEM INTERFACE
+        $<INSTALL_INTERFACE:${COLMAP_BOOST_UNORDERED_INSTALL_DIR}>)
+    message(STATUS "Configuring boost-unordered (${_boost_unordered_tag})... done")
+endif()
+
 if(FETCH_POSELIB)
     include(FetchContent)
     FetchContent_Declare(poselib

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -42,18 +42,17 @@ endif()
 # boost/unordered/unordered_{flat,node}_{map,set}.hpp, ~5 MB in total.
 if(NOT COLMAP_BOOST_UNORDERED_FROM_SYSTEM AND FETCH_BOOST_UNORDERED)
     include(FetchContent)
-    set(_boost_unordered_tag "boost-1.90.0")
+    set(_boost_unordered_tag "boost-1.92.0")
     set(_boost_unordered_modules
-        unordered       7dd15a1196e36de483fc287a5487210b596979761c4708b4c3067a717c765a05
-        assert          1f48f929e69146db222fdf9538ec81c7cbd3ca88b94343644942b477031a3bba
-        config          1390bd79fbf270e40cfe5ac6b899f4a9c4e47139b6e17b4c1f7f78822adaa9fc
-        container_hash  415d6a01b2d8a07ab36dbf9e31a8fec6fa0e51185d1015a087c153de28cfaba5
-        core            0444b7741bcf20f80ff6a4d191a920f6aba92d26734c81fa481f8fd0a274b487
-        describe        4ca9c54d50c5bd8ec68811475ef96ec1ac0abbfbf19f55789823aabcbb704812
-        mp11            ca52bde753586dcba29739cfd55abb473bf80c934c6d49a2b58023ed4e48adf6
-        predef          d9144eb3c7d965991e8798fc7e96d5ea862951bffcbdba0b8a23892fd5c99f7c
-        static_assert   3b7980c5968d585b04f980bbb4e81bbbf0b6d1a0b7c965c2a3426b0acb4a5f49
-        throw_exception 30e2834ba64587a363750e35c627ee045f89be05d0cc9eab7251414eba88e110
+        unordered       cc2eac1c597c221f20d166273825bba3581e64b75c295e97eb67bd5444d4bef0
+        assert          8d49fc69df12e8fbc0e7fe3c4ede45044747199ccdeaf66c2aebb146becc54aa
+        config          b4171037f13373203ba79cbc141d612982052283e696a315185ab5bea46102a0
+        container_hash  f88aabbbc2f163db5eea65662b26e5af2bde0a0bff065c645b7347ed6a71a566
+        core            aa4eb2ccbe5577ded70f25b8f0d852a5246591f90cc34916160739e3d0dbfea6
+        describe        4ef61ea2ca967b803e171f4756e03e201680d5dd19d014324f9a848e0d06863b
+        mp11            a5754dc5ff9e7ff34119983889530e3ab8d8fb43ce2b4fea9c18673044df45d9
+        predef          4c870bcf7f547f3e3d1db26700b078a33f87c4c8232cd1c8d89ec82be6b54130
+        throw_exception 1ddbb967a43504e28bbe2a35a010df9f7ff5d1a49d3678c9fdfc035fd32ce005
     )
     message(STATUS "Configuring boost-unordered (${_boost_unordered_tag})...")
     add_library(colmap_boost_unordered INTERFACE)

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -56,6 +56,14 @@ if(NOT COLMAP_BOOST_UNORDERED_FROM_SYSTEM AND FETCH_BOOST_UNORDERED)
     )
     message(STATUS "Configuring boost-unordered (${_boost_unordered_tag})...")
     add_library(colmap_boost_unordered INTERFACE)
+    # These headers shadow the same modules in the older system Boost, so the
+    # rest of Boost (property_tree, graph, ...) ends up calling into them. Where
+    # the newer copy has since deprecated a symbol the older callers still use
+    # -- boost::swap in boost/core, called by property_tree -- the diagnostic is
+    # attributed to the instantiation site in COLMAP's own sources rather than
+    # to a system header, so it is not suppressed and -Werror rejects it.
+    target_compile_definitions(colmap_boost_unordered INTERFACE
+        BOOST_ALLOW_DEPRECATED)
     while(_boost_unordered_modules)
         list(POP_FRONT _boost_unordered_modules _module _hash)
         # SOURCE_SUBDIR names a directory without a CMakeLists.txt so that the


### PR DESCRIPTION
Alternative to #4676 — **only one of the two should be merged.**

Both PRs make `boost::unordered` the only hash container backend (see #4676 for that rationale, which is unchanged here). They differ only in how a new enough boost-unordered is guaranteed on distros whose Boost is older than 1.84.

## Why an alternative

#4676 vendors just the nine header-only modules in boost-unordered's include closure. To win, those headers have to sit ahead of the system Boost on the include path — which also shadows the support modules they bring with them (`core`, `config`, `mp11`, `container_hash`, ...). The rest of the system Boost then compiles against them.

That is already visible: on Ubuntu 24.04, system Boost 1.83's `property_tree` calls `boost::swap`, which vendored 1.92's `boost/core` has deprecated. #4676 needs `BOOST_ALLOW_DEPRECATED` to build. The deprecation is benign, but the shadowing it reveals is not bounded to warnings: **`Boost::graph` and `Boost::program_options` are compiled, dynamically linked system libraries**, and their headers are now being compiled against newer support headers than the `.so` was built from.

Extending the vendored set to cover `property_tree` makes this worse, not better: its closure adds `mpl`, `type_traits`, `iterator`, `range`, `concept_check`, `preprocessor` — 20 modules, ~23 MB of headers — which is most of what Boost.Graph's headers are built out of.

## What this PR does instead

Take all of Boost from one place, so headers and compiled libraries always match.

A system Boost >= 1.84 is always preferred and used as it is — that is the case on Ubuntu 26.04 (1.90), homebrew (1.92) and vcpkg, where nothing is downloaded and nothing extra is installed.

- Only where no such Boost is found does `FETCH_BOOST` kick in: it downloads the pinned `boost-1.92.0-cmake.tar.xz` release archive and builds it as a subproject. It is ON by default, but unlike `FETCH_POSELIB`/`FETCH_FAISS`/`FETCH_ONNX` that does not mean Boost gets fetched — it is a fallback switch, and turning it OFF makes a too-old system Boost a configure-time error instead.
- `BOOST_INCLUDE_LIBRARIES` limits configuration to the ten libraries COLMAP uses plus their dependencies; only `graph`, `program_options` and their compiled deps actually build.
- `BOOST_SKIP_INSTALL_RULES=OFF` — Boost defaults to skipping its install rules as a subproject, which would both leave the headers out of COLMAP's install tree and keep its targets out of any export set.
- Boost installs into COLMAP's prefix, and `colmap-config.cmake` points consumers at that copy rather than re-fetching or falling back to their own Boost.
- No `BOOST_ALLOW_DEPRECATED`, no `SYSTEM BEFORE` include-path juggling, no `colmap_boost_unordered` target.

`Boost::boost`, `Boost::graph` and `Boost::program_options` are all provided by Boost's own CMake build, so every existing link line in COLMAP is unchanged.

One ordering change was required: `colmap-config.cmake` now includes `FindDependencies.cmake` **before** `colmap-targets.cmake`. A vendored Boost is exported from its own export set rather than imported, so CMake generates an existence check for those targets in the targets file.

## Cost, measured

| | #4676 | this PR |
|---|---|---|
| download | 4.8 MB, always | 102 MB (`.tar.xz`), only when the system Boost is too old |
| extracted | — | 692 MB |
| Boost configure | — | ~4 s |
| Boost build | — | **~8 s** (88 targets, 10 cores) |
| headers installed | 3.2 MB, always | 110 MB, only when fetched |
| shadows system Boost | yes, 9 modules | no |

The build time is negligible. The real cost is the 102 MB download and a larger install tree, and it is only paid on distros whose Boost is older than 1.84 (Ubuntu 24.04 and earlier).

## Verified locally (macOS, arm64)

- System-Boost path (1.92): configures, `Using system Boost 1.92.0`.
- Forced-fetch path: configures, builds all 479 targets, installs (292 MB total), and `doc/sample-project` configures, builds and **runs** against the install tree — including Boost.ProgramOptions parsing, i.e. the vendored compiled library is the one being linked.

## Open question for CI

COLMAP is not Boost's only consumer in its own link line — CGAL in particular is built on Boost headers and, on a distro build, was packaged against the system Boost. This PR does not shadow Boost for COLMAP's own translation units any more, but a distro CGAL still gets compiled against the vendored headers. That boundary is what CI needs to answer here, the same way Ubuntu 22.04 was the open question for #4676.

