### PR TITLE
Fix image triangulator progress counter

### DIFF
--- a/src/colmap/controllers/incremental_pipeline.cc
+++ b/src/colmap/controllers/incremental_pipeline.cc
@@ -866,7 +866,7 @@ void IncrementalPipeline::TriangulateReconstruction(
     const auto& image = reconstruction->Image(image_id);
 
     LOG(INFO) << StringPrintf(
-        "Triangulating image #%d (%d)", image_id, image_idx++);
+        "Triangulating image #%d (%d)", image_id, ++image_idx);
     const size_t num_existing_points3D = image.NumPoints3D();
     LOG(INFO) << "=> Image sees " << num_existing_points3D << " / "
               << mapper.ObservationManager().NumObservations(image_id)


### PR DESCRIPTION
Fix the image triangulator progress log to use one-based indexing. The first processed image is now reported as `(1)` instead of `(0)`.

Test: `cmake --build build --target colmap_controllers -j2`