### PR TITLE
Remove pycolmap deprecations predating 4.2.0

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -304,23 +304,35 @@ import numpy as np
 import pycolmap
 from PIL import Image, ImageOps
 
-# Input should be grayscale image with range [0, 1].
+# Input should be a grayscale bitmap.
 img = Image.open('image.jpg').convert('RGB')
 img = ImageOps.grayscale(img)
-img = np.array(img).astype(np.float) / 255.
+bitmap = pycolmap.Bitmap.from_array(np.array(img))
 
 # Optional parameters:
-# - options: dict or pycolmap.SiftExtractionOptions
+# - options: pycolmap.FeatureExtractionOptions (default: SIFT)
 # - device: default pycolmap.Device.auto uses the GPU if available
-sift = pycolmap.Sift()
+extractor = pycolmap.FeatureExtractor.create()
 
 # Parameters:
-# - image: HxW float array
-keypoints, descriptors = sift.extract(img)
+# - bitmap: pycolmap.Bitmap (grayscale for SIFT)
+keypoints, descriptors = extractor.extract(bitmap)
 # Returns:
-# - keypoints: Nx4 array; format: x (j), y (i), scale, orientation
-# - descriptors: Nx128 array; L2-normalized descriptors
+# - keypoints: pycolmap.FeatureKeypoints; use
+#   pycolmap.keypoints_to_matrix(keypoints) for the Nx4 array with
+#   format: x (j), y (i), scale, orientation
+# - descriptors: pycolmap.FeatureDescriptors; use
+#   descriptors.to_float().data / 512 for the Nx128 array of
+#   L2-normalized descriptors
 ```
+
+Note: unlike the removed `pycolmap.Sift.extract`, `extract` processes the
+image as-is. It does not downscale large images to
+`options.eff_max_image_size()` (3200 by default) and does not rescale the
+keypoint coordinates and scales back to the original resolution. Downscale
+large images yourself before extraction to reproduce the old behavior; in
+particular, the GPU backend requires images within its configured maximum
+dimension.
 
 ## Bitmap
 

--- a/python/examples/convert_legacy_rotation_averaging_format.py
+++ b/python/examples/convert_legacy_rotation_averaging_format.py
@@ -177,7 +177,7 @@ def create_database_from_relative_poses(
         camera_id = image_id
 
         # Create camera with trivial rig (rig_id = camera_id)
-        camera = pycolmap.Camera.create(
+        camera = pycolmap.Camera.create_from_model_id(
             camera_id=camera_id,
             model=pycolmap.CameraModelId.SIMPLE_PINHOLE,
             focal_length=1.0,

--- a/src/pycolmap/feature/extraction.cc
+++ b/src/pycolmap/feature/extraction.cc
@@ -21,8 +21,6 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-static std::map<int, std::unique_ptr<std::mutex>> sift_gpu_mutexes;
-
 namespace {
 
 class PyFeatureExtractor : public FeatureExtractor,

--- a/src/pycolmap/feature/extraction.cc
+++ b/src/pycolmap/feature/extraction.cc
@@ -21,14 +21,6 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-template <typename dtype>
-using pyimage_t =
-    Eigen::Matrix<dtype, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
-
-typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
-    descriptors_t;
-typedef std::tuple<FeatureKeypointsMatrix, descriptors_t> sift_output_t;
-
 static std::map<int, std::unique_ptr<std::mutex>> sift_gpu_mutexes;
 
 namespace {
@@ -59,58 +51,6 @@ class PyFeatureExtractor : public FeatureExtractor,
 };
 
 }  // namespace
-
-class Sift {
- public:
-  Sift(std::optional<FeatureExtractionOptions> options, Device device)
-      : use_gpu_(IsGPU(device)) {
-    PyErr_WarnEx(PyExc_DeprecationWarning,
-                 "pycolmap.Sift is deprecated, use "
-                 "pycolmap.FeatureExtractor.create() instead.",
-                 1);
-    if (options) {
-      options_ = std::move(*options);
-    }
-    options_.use_gpu = use_gpu_;
-    extractor_ = THROW_CHECK_NOTNULL(CreateSiftFeatureExtractor(options_));
-  }
-
-  sift_output_t Extract(const Eigen::Ref<const pyimage_t<uint8_t>>& image) {
-    Bitmap bitmap(image.cols(), image.rows(), /*as_rgb=*/false);
-    std::memcpy(bitmap.RowMajorData().data(), image.data(), bitmap.NumBytes());
-
-    const double scale = bitmap.Thumbnail(options_.EffMaxImageSize());
-
-    FeatureKeypoints feature_keypoints;
-    FeatureDescriptors feature_descriptors;
-    THROW_CHECK(
-        extractor_->Extract(bitmap, &feature_keypoints, &feature_descriptors));
-
-    FeatureKeypointsMatrix keypoints = KeypointsToMatrix(feature_keypoints);
-    const double inv_scale = 1.0 / scale;
-    keypoints.col(0) *= inv_scale;
-    keypoints.col(1) *= inv_scale;
-    keypoints.col(2) *= inv_scale;
-    descriptors_t descriptors = feature_descriptors.ToFloat().data;
-    descriptors /= 512.0f;
-
-    return std::make_tuple(std::move(keypoints), std::move(descriptors));
-  }
-
-  sift_output_t Extract(const Eigen::Ref<const pyimage_t<float>>& image) {
-    const pyimage_t<uint8_t> image_f = (image * 255.0f).cast<uint8_t>();
-    return Extract(image_f);
-  }
-
-  const FeatureExtractionOptions& Options() const { return options_; };
-
-  Device GetDevice() const { return (use_gpu_) ? Device::CUDA : Device::CPU; };
-
- private:
-  std::unique_ptr<FeatureExtractor> extractor_;
-  FeatureExtractionOptions options_;
-  bool use_gpu_ = false;
-};
 
 void BindFeatureExtraction(py::module& m) {
   auto PyNormalization =
@@ -333,19 +273,4 @@ void BindFeatureExtraction(py::module& m) {
           "Extract features from a float32 numpy array with values in "
           "[0, 1] and shape (H, W) or (H, W, 3). Returns "
           "(FeatureKeypoints, FeatureDescriptors).");
-
-  py::classh<Sift>(m, "Sift")
-      .def(py::init<std::optional<FeatureExtractionOptions>, Device>(),
-           "options"_a = std::nullopt,
-           "device"_a = Device::AUTO)
-      .def("extract",
-           py::overload_cast<const Eigen::Ref<const pyimage_t<uint8_t>>&>(
-               &Sift::Extract),
-           "image"_a.noconvert())
-      .def("extract",
-           py::overload_cast<const Eigen::Ref<const pyimage_t<float>>&>(
-               &Sift::Extract),
-           "image"_a.noconvert())
-      .def_property_readonly("options", &Sift::Options)
-      .def_property_readonly("device", &Sift::GetDevice);
 }

--- a/src/pycolmap/feature/extraction_test.py
+++ b/src/pycolmap/feature/extraction_test.py
@@ -104,15 +104,3 @@ def test_feature_extraction_options_check() -> None:
 def test_feature_extractor_create() -> None:
     extractor = pycolmap.FeatureExtractor.create(device=pycolmap.Device.cpu)
     assert extractor is not None
-
-
-def test_sift_deprecated_class() -> None:
-    if hasattr(pycolmap, "Sift"):
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            sift = pycolmap.Sift(device=pycolmap.Device.cpu)
-            assert sift is not None
-            assert sift.options is not None
-            assert sift.device is not None

--- a/src/pycolmap/geometry/pose_prior.cc
+++ b/src/pycolmap/geometry/pose_prior.cc
@@ -33,8 +33,6 @@ void BindPosePrior(py::module& m) {
       .def("has_position", &PosePrior::HasPosition)
       .def("has_position_cov", &PosePrior::HasPositionCov)
       .def("has_gravity", &PosePrior::HasGravity);
-  DefDeprecation(PyPosePrior, "is_valid", "has_position");
-  DefDeprecation(PyPosePrior, "is_covariance_valid", "has_position_cov");
   MakeDataclass(PyPosePrior);
 
   m.def("compute_rot90_from_gravity",

--- a/src/pycolmap/scene/camera.cc
+++ b/src/pycolmap/scene/camera.cc
@@ -272,7 +272,6 @@ void BindCamera(py::module& m) {
            "scale"_a,
            "Rescale the camera dimensions and accordingly the "
            "focal length and the principal point.");
-  DefDeprecation(PyCamera, "create", "create_from_model_id");
   MakeDataclass(PyCamera,
                 {"camera_id",
                  "model",

--- a/src/pycolmap/scene/correspondence_graph.cc
+++ b/src/pycolmap/scene/correspondence_graph.cc
@@ -136,13 +136,4 @@ void BindCorrespondenceGraph(py::module& m) {
              return CorrespondenceGraph(self);
            })
       .def("__repr__", &CreateRepresentation<CorrespondenceGraph>);
-  DefDeprecation(PyCorrespondenceGraph,
-                 "num_correspondences_between_images",
-                 "num_matches_between_images");
-  DefDeprecation(PyCorrespondenceGraph,
-                 "num_correspondences_between_all_images",
-                 "num_matches_between_all_images");
-  DefDeprecation(PyCorrespondenceGraph,
-                 "find_correspondences_between_images",
-                 "extract_matches_between_images");
 }


### PR DESCRIPTION
Follow-up to #4081, which kept these entries as too new at the time. All of them shipped deprecated in 4.2.0, so they can go now:

- `feature/extraction.cc`: remove deprecated `Sift` class in favor of `FeatureExtractor.create()`, plus its test and unused local typedefs.
- `scene/camera.cc`: remove `Camera.create` alias of `create_from_model_id`.
- `geometry/pose_prior.cc`: remove `PosePrior.is_valid` / `is_covariance_valid` aliases of `has_position` / `has_position_cov`.
- `scene/correspondence_graph.cc`: remove `num_correspondences_between_images`, `num_correspondences_between_all_images`, and `find_correspondences_between_images` aliases.

Deliberately left alone:
- `DefDeprecation` helper in `helpers.h` (generic infra for future deprecations).
- `is_deprecated_image_prior` in the `Database` bindings, which mirrors the C++ core interface and needs a core-side decision first.

Test plan:
- All 4 edited translation units recompile cleanly (full `_core` link is blocked by a stale `install/lib` in this checkout — pre-existing, unrelated).
- `pytest src/pycolmap/feature/extraction_test.py src/pycolmap/geometry/pose_prior_test.py src/pycolmap/scene/camera_test.py src/pycolmap/scene/correspondence_graph_test.py`: 92 passed.
- `ruff check` + `ruff format --check` on the edited test file pass.