### PR TITLE
Add ScaleWeightedCostFunctor for stddev-based residual whitening

### DIFF
--- a/benchmark/runtime/cost_functions.cc
+++ b/benchmark/runtime/cost_functions.cc
@@ -195,6 +195,35 @@ void BM_ReprojErrorConstantPose(benchmark::State& state, bool analytic) {
   }
 }
 
+// Covariance-weighted reprojection error. Guards that the weighted dispatch
+// still routes to the analytical jacobian: if it regresses to autodiff, this
+// drops to the AutoDiff timing above.
+template <typename CameraModel>
+void BM_WeightedReprojError(benchmark::State& state, bool analytic) {
+  ReprojErrorData data = CreateReprojErrorData<CameraModel>();
+  const Eigen::Matrix2d covariance = 4.0 * Eigen::Matrix2d::Identity();
+  std::unique_ptr<ceres::CostFunction> cost_function(
+      analytic
+          ? CreateCovarianceWeightedCameraCostFunction<ReprojErrorCostFunctor>(
+                CameraModel::model_id, covariance, data.point2D)
+          : CovarianceWeightedCostFunctor<
+                ReprojErrorCostFunctor<CameraModel>>::Create(covariance,
+                                                             data.point2D));
+
+  const double* parameters[3] = {data.point3D.data(),
+                                 data.cam_from_world.params.data(),
+                                 data.camera_params.data()};
+  double residuals[2];
+  double jacobian_point[2 * 3];
+  double jacobian_pose[2 * 7];
+  double jacobian_params[2 * CameraModel::num_params];
+  double* jacobians[3] = {jacobian_point, jacobian_pose, jacobian_params};
+
+  for (auto _ : state) {
+    cost_function->Evaluate(parameters, residuals, jacobians);
+  }
+}
+
 }  // namespace
 
 #define REGISTER_MODEL(Model)                                                \
@@ -203,7 +232,11 @@ void BM_ReprojErrorConstantPose(benchmark::State& state, bool analytic) {
   BENCHMARK_CAPTURE(                                                         \
       BM_ReprojErrorConstantPose<Model>, Model##_ConstPose_AutoDiff, false); \
   BENCHMARK_CAPTURE(                                                         \
-      BM_ReprojErrorConstantPose<Model>, Model##_ConstPose_Analytic, true);
+      BM_ReprojErrorConstantPose<Model>, Model##_ConstPose_Analytic, true);  \
+  BENCHMARK_CAPTURE(                                                         \
+      BM_WeightedReprojError<Model>, Model##_Weighted_AutoDiff, false);      \
+  BENCHMARK_CAPTURE(                                                         \
+      BM_WeightedReprojError<Model>, Model##_Weighted_Analytic, true);
 
 REGISTER_MODEL(SimplePinholeCameraModel)
 REGISTER_MODEL(PinholeCameraModel)

--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -1029,32 +1029,43 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
 
     const Eigen::Vector3d normalized_position =
         normalized_from_metric_ * pose_prior.position;
-    const Eigen::Matrix3d normalized_from_metric_scaled_rotation =
+    // The fallback is isotropic and stays isotropic under the similarity
+    // transform, so it only needs a scale rather than a whitening matrix.
+    const double normalized_position_stddev =
         normalized_from_metric_.scale() *
-        normalized_from_metric_.rotation().toRotationMatrix();
-    const Eigen::Matrix3d position_cov =
-        pose_prior.HasPositionCov()
-            ? pose_prior.position_covariance
-            : (prior_options_.prior_position_fallback_stddev *
-               prior_options_.prior_position_fallback_stddev *
-               Eigen::Matrix3d::Identity());
-    const Eigen::Matrix3d normalized_position_cov =
-        normalized_from_metric_scaled_rotation * position_cov *
-        normalized_from_metric_scaled_rotation.transpose();
+        prior_options_.prior_position_fallback_stddev;
+    Eigen::Matrix3d normalized_position_cov;
+    if (pose_prior.HasPositionCov()) {
+      const Eigen::Matrix3d normalized_from_metric_scaled_rotation =
+          normalized_from_metric_.scale() *
+          normalized_from_metric_.rotation().toRotationMatrix();
+      normalized_position_cov =
+          normalized_from_metric_scaled_rotation *
+          pose_prior.position_covariance *
+          normalized_from_metric_scaled_rotation.transpose();
+    }
 
     if (image.IsRefInFrame()) {
       problem.AddResidualBlock(
-          CovarianceWeightedCostFunctor<AbsolutePosePositionPriorCostFunctor>::
-              Create(normalized_position_cov, normalized_position),
+          pose_prior.HasPositionCov()
+              ? CovarianceWeightedCostFunctor<
+                    AbsolutePosePositionPriorCostFunctor>::
+                    Create(normalized_position_cov, normalized_position)
+              : ScaleWeightedCostFunctor<AbsolutePosePositionPriorCostFunctor>::
+                    Create(normalized_position_stddev, normalized_position),
           prior_loss_function_.get(),
           rig_from_world.params.data());
     } else {
       Rigid3d& cam_from_rig =
           frame.RigPtr()->SensorFromRig(image.CameraPtr()->SensorId());
       problem.AddResidualBlock(
-          CovarianceWeightedCostFunctor<
-              AbsoluteRigPosePositionPriorCostFunctor>::
-              Create(normalized_position_cov, normalized_position),
+          pose_prior.HasPositionCov()
+              ? CovarianceWeightedCostFunctor<
+                    AbsoluteRigPosePositionPriorCostFunctor>::
+                    Create(normalized_position_cov, normalized_position)
+              : ScaleWeightedCostFunctor<
+                    AbsoluteRigPosePositionPriorCostFunctor>::
+                    Create(normalized_position_stddev, normalized_position),
           prior_loss_function_.get(),
           cam_from_rig.params.data(),
           rig_from_world.params.data());

--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -1012,45 +1012,18 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
 
     Rigid3d& rig_from_world = frame.RigFromWorld();
 
-    const Eigen::Vector3d normalized_position =
-        normalized_from_metric_ * pose_prior.position;
-    // The fallback is isotropic and stays isotropic under the similarity
-    // transform, so it only needs a scale rather than a whitening matrix.
-    const double normalized_position_stddev =
-        normalized_from_metric_.scale() *
-        prior_options_.prior_position_fallback_stddev;
-    Eigen::Matrix3d normalized_position_cov;
-    if (pose_prior.HasPositionCov()) {
-      const Eigen::Matrix3d normalized_from_metric_scaled_rotation =
-          normalized_from_metric_.scale() *
-          normalized_from_metric_.rotation().toRotationMatrix();
-      normalized_position_cov =
-          normalized_from_metric_scaled_rotation *
-          pose_prior.position_covariance *
-          normalized_from_metric_scaled_rotation.transpose();
-    }
-
     if (image.IsRefInFrame()) {
       problem.AddResidualBlock(
-          pose_prior.HasPositionCov()
-              ? CovarianceWeightedCostFunctor<
-                    AbsolutePosePositionPriorCostFunctor>::
-                    Create(normalized_position_cov, normalized_position)
-              : ScaleWeightedCostFunctor<AbsolutePosePositionPriorCostFunctor>::
-                    Create(normalized_position_stddev, normalized_position),
+          CreatePositionPriorCostFunction<AbsolutePosePositionPriorCostFunctor>(
+              pose_prior),
           prior_loss_function_.get(),
           rig_from_world.params.data());
     } else {
       Rigid3d& cam_from_rig =
           frame.RigPtr()->SensorFromRig(image.CameraPtr()->SensorId());
       problem.AddResidualBlock(
-          pose_prior.HasPositionCov()
-              ? CovarianceWeightedCostFunctor<
-                    AbsoluteRigPosePositionPriorCostFunctor>::
-                    Create(normalized_position_cov, normalized_position)
-              : ScaleWeightedCostFunctor<
-                    AbsoluteRigPosePositionPriorCostFunctor>::
-                    Create(normalized_position_stddev, normalized_position),
+          CreatePositionPriorCostFunction<
+              AbsoluteRigPosePositionPriorCostFunctor>(pose_prior),
           prior_loss_function_.get(),
           cam_from_rig.params.data(),
           rig_from_world.params.data());
@@ -1063,6 +1036,30 @@ class PosePriorBundleAdjuster : public CeresBundleAdjuster {
     if (constant_rig_from_world) {
       problem.SetParameterBlockConstant(rig_from_world.params.data());
     }
+  }
+
+  // Weights the prior by its covariance, or by the isotropic fallback stddev
+  // when it has none. An isotropic covariance stays isotropic under the
+  // similarity transform, so the fallback only needs a scale.
+  template <typename CostFunctor>
+  ceres::CostFunction* CreatePositionPriorCostFunction(
+      const PosePrior& pose_prior) const {
+    const Eigen::Vector3d normalized_position =
+        normalized_from_metric_ * pose_prior.position;
+    if (pose_prior.HasPositionCov()) {
+      const Eigen::Matrix3d normalized_from_metric_scaled_rotation =
+          normalized_from_metric_.scale() *
+          normalized_from_metric_.rotation().toRotationMatrix();
+      return CovarianceWeightedCostFunctor<CostFunctor>::Create(
+          normalized_from_metric_scaled_rotation *
+              pose_prior.position_covariance *
+              normalized_from_metric_scaled_rotation.transpose(),
+          normalized_position);
+    }
+    return ScaleWeightedCostFunctor<CostFunctor>::Create(
+        normalized_from_metric_.scale() *
+            prior_options_.prior_position_fallback_stddev,
+        normalized_position);
   }
 
   bool AlignReconstruction() {

--- a/src/colmap/estimators/cost_functions/reprojection_error.h
+++ b/src/colmap/estimators/cost_functions/reprojection_error.h
@@ -493,6 +493,7 @@ ceres::CostFunction* CreateCovarianceWeightedCameraCostFunction(
     const CameraModelId camera_model_id,
     const Covariance& covariance,
     Args&&... args) {
+  // NOLINTBEGIN(bugprone-macro-parentheses)
   switch (camera_model_id) {
 #define CAMERA_MODEL_CASE(CameraModel)                                       \
   case CameraModel::model_id:                                                \
@@ -506,6 +507,7 @@ ceres::CostFunction* CreateCovarianceWeightedCameraCostFunction(
 
 #undef CAMERA_MODEL_CASE
   }
+  // NOLINTEND(bugprone-macro-parentheses)
 }
 
 template <template <typename> class CostFunctor,
@@ -513,6 +515,7 @@ template <template <typename> class CostFunctor,
           typename... Args>
 ceres::CostFunction* CreateScaleWeightedCameraCostFunction(
     const CameraModelId camera_model_id, const Stddev& stddev, Args&&... args) {
+  // NOLINTBEGIN(bugprone-macro-parentheses)
   switch (camera_model_id) {
 #define CAMERA_MODEL_CASE(CameraModel)                                       \
   case CameraModel::model_id:                                                \
@@ -526,6 +529,7 @@ ceres::CostFunction* CreateScaleWeightedCameraCostFunction(
 
 #undef CAMERA_MODEL_CASE
   }
+  // NOLINTEND(bugprone-macro-parentheses)
 }
 
 }  // namespace colmap

--- a/src/colmap/estimators/cost_functions/reprojection_error.h
+++ b/src/colmap/estimators/cost_functions/reprojection_error.h
@@ -482,4 +482,50 @@ ceres::CostFunction* CreateCameraCostFunction(
   // NOLINTEND(bugprone-macro-parentheses)
 }
 
+// Same as CreateCameraCostFunction, but whitens the result. The weight is a
+// separate parameter so that the inner cost function is still built from the
+// unwrapped functor, which keeps the analytical jacobian for camera models
+// that provide one.
+template <template <typename> class CostFunctor,
+          typename Covariance,
+          typename... Args>
+ceres::CostFunction* CreateCovarianceWeightedCameraCostFunction(
+    const CameraModelId camera_model_id,
+    const Covariance& covariance,
+    Args&&... args) {
+  switch (camera_model_id) {
+#define CAMERA_MODEL_CASE(CameraModel)                                       \
+  case CameraModel::model_id:                                                \
+    return CreateCovarianceWeightedCostFunction<CostFunctor<CameraModel>>(   \
+        covariance,                                                          \
+        CreateCameraCostFunction<CostFunctor>(camera_model_id,               \
+                                              std::forward<Args>(args)...)); \
+    break;
+
+    CAMERA_MODEL_SWITCH_CASES
+
+#undef CAMERA_MODEL_CASE
+  }
+}
+
+template <template <typename> class CostFunctor,
+          typename Stddev,
+          typename... Args>
+ceres::CostFunction* CreateScaleWeightedCameraCostFunction(
+    const CameraModelId camera_model_id, const Stddev& stddev, Args&&... args) {
+  switch (camera_model_id) {
+#define CAMERA_MODEL_CASE(CameraModel)                                       \
+  case CameraModel::model_id:                                                \
+    return CreateScaleWeightedCostFunction<CostFunctor<CameraModel>>(        \
+        stddev,                                                              \
+        CreateCameraCostFunction<CostFunctor>(camera_model_id,               \
+                                              std::forward<Args>(args)...)); \
+    break;
+
+    CAMERA_MODEL_SWITCH_CASES
+
+#undef CAMERA_MODEL_CASE
+  }
+}
+
 }  // namespace colmap

--- a/src/colmap/estimators/cost_functions/reprojection_error_test.cc
+++ b/src/colmap/estimators/cost_functions/reprojection_error_test.cc
@@ -32,7 +32,9 @@
 #include "colmap/geometry/rigid3.h"
 #include "colmap/math/random.h"
 #include "colmap/sensor/models.h"
+#include "colmap/util/eigen_matchers.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -423,6 +425,98 @@ TEST(CovarianceWeightedCostFunctor, ReprojErrorCostFunctor) {
   EXPECT_TRUE(cost_function2->Evaluate(parameters, residuals, nullptr));
   EXPECT_EQ(residuals[0], -1);
   EXPECT_EQ(residuals[1], 1);
+}
+
+// The weighted dispatch must agree with whitening the dispatched cost function
+// by hand, for every camera model. This is what lets the inner cost function
+// keep its analytical jacobian.
+template <typename CameraModel>
+void TestWeightedCameraCostFunction() {
+  const Eigen::Vector2d point2D(0.7, -0.3);
+  const double stddev = 2.0;
+  const Eigen::Matrix2d covariance =
+      stddev * stddev * Eigen::Matrix2d::Identity();
+
+  double cam_from_world[7] = {0, 0, 0, 1, 0.1, 0.2, 3.0};
+  double point3D[3] = {0.3, -0.2, 5.0};
+  std::vector<double> camera_params(CameraModel::num_params, 0.0);
+  for (size_t i = 0; i < camera_params.size(); ++i) {
+    camera_params[i] = 0.1 * (i + 1);
+  }
+  camera_params[0] = 100.0;
+  const double* parameters[3] = {point3D, cam_from_world, camera_params.data()};
+
+  std::unique_ptr<ceres::CostFunction> unweighted(
+      CreateCameraCostFunction<ReprojErrorCostFunctor>(CameraModel::model_id,
+                                                       point2D));
+  std::unique_ptr<ceres::CostFunction> cov_weighted(
+      CreateCovarianceWeightedCameraCostFunction<ReprojErrorCostFunctor>(
+          CameraModel::model_id, covariance, point2D));
+  std::unique_ptr<ceres::CostFunction> scale_weighted(
+      CreateScaleWeightedCameraCostFunction<ReprojErrorCostFunctor>(
+          CameraModel::model_id, stddev, point2D));
+
+  const int num_params = CameraModel::num_params;
+  Eigen::Vector2d unweighted_residuals;
+  Eigen::Vector2d cov_residuals;
+  Eigen::Vector2d scale_residuals;
+  Eigen::Matrix<double, 2, 3, Eigen::RowMajor> unweighted_jacobian_point;
+  Eigen::Matrix<double, 2, 7, Eigen::RowMajor> unweighted_jacobian_pose;
+  Eigen::MatrixXd unweighted_jacobian_params(2, num_params);
+  Eigen::Matrix<double, 2, 3, Eigen::RowMajor> cov_jacobian_point;
+  Eigen::Matrix<double, 2, 7, Eigen::RowMajor> cov_jacobian_pose;
+  Eigen::MatrixXd cov_jacobian_params(2, num_params);
+  Eigen::Matrix<double, 2, 3, Eigen::RowMajor> scale_jacobian_point;
+  Eigen::Matrix<double, 2, 7, Eigen::RowMajor> scale_jacobian_pose;
+  Eigen::MatrixXd scale_jacobian_params(2, num_params);
+  double* unweighted_jacobians[3] = {unweighted_jacobian_point.data(),
+                                     unweighted_jacobian_pose.data(),
+                                     unweighted_jacobian_params.data()};
+  double* cov_jacobians[3] = {cov_jacobian_point.data(),
+                              cov_jacobian_pose.data(),
+                              cov_jacobian_params.data()};
+  double* scale_jacobians[3] = {scale_jacobian_point.data(),
+                                scale_jacobian_pose.data(),
+                                scale_jacobian_params.data()};
+
+  ASSERT_TRUE(unweighted->Evaluate(
+      parameters, unweighted_residuals.data(), unweighted_jacobians));
+  ASSERT_TRUE(
+      cov_weighted->Evaluate(parameters, cov_residuals.data(), cov_jacobians));
+  ASSERT_TRUE(scale_weighted->Evaluate(
+      parameters, scale_residuals.data(), scale_jacobians));
+
+  // Whitening by an isotropic covariance is a division by stddev.
+  EXPECT_THAT(
+      cov_residuals,
+      EigenMatrixNear(Eigen::Vector2d(unweighted_residuals / stddev), 1e-10));
+  EXPECT_THAT(cov_jacobian_point,
+              EigenMatrixNear(Eigen::Matrix<double, 2, 3, Eigen::RowMajor>(
+                                  unweighted_jacobian_point / stddev),
+                              1e-10));
+  EXPECT_THAT(cov_jacobian_pose,
+              EigenMatrixNear(Eigen::Matrix<double, 2, 7, Eigen::RowMajor>(
+                                  unweighted_jacobian_pose / stddev),
+                              1e-10));
+  EXPECT_THAT(cov_jacobian_params,
+              EigenMatrixNear(
+                  Eigen::MatrixXd(unweighted_jacobian_params / stddev), 1e-10));
+
+  // The scale form must match the equivalent isotropic covariance.
+  EXPECT_THAT(scale_residuals, EigenMatrixNear(cov_residuals, 1e-10));
+  EXPECT_THAT(scale_jacobian_point, EigenMatrixNear(cov_jacobian_point, 1e-10));
+  EXPECT_THAT(scale_jacobian_pose, EigenMatrixNear(cov_jacobian_pose, 1e-10));
+  EXPECT_THAT(scale_jacobian_params,
+              EigenMatrixNear(cov_jacobian_params, 1e-10));
+}
+
+TEST(WeightedCameraCostFunction, MatchesDispatchedCostFunction) {
+  TestWeightedCameraCostFunction<SimplePinholeCameraModel>();
+  TestWeightedCameraCostFunction<PinholeCameraModel>();
+  TestWeightedCameraCostFunction<SimpleRadialCameraModel>();
+  TestWeightedCameraCostFunction<RadialCameraModel>();
+  TestWeightedCameraCostFunction<OpenCVCameraModel>();
+  TestWeightedCameraCostFunction<FullOpenCVCameraModel>();
 }
 
 TEST(RigReprojErrorCostFunctor, Nominal) {

--- a/src/colmap/estimators/cost_functions/utils.h
+++ b/src/colmap/estimators/cost_functions/utils.h
@@ -31,10 +31,10 @@
 
 #include "colmap/util/eigen_alignment.h"
 
+#include <memory>
+
 #include <Eigen/Core>
 #include <ceres/ceres.h>
-
-#include <memory>
 
 namespace colmap {
 
@@ -124,8 +124,9 @@ template <class CostFunctor, class ParameterDims>
 class CovarianceWeightedCostFunction;
 
 template <class CostFunctor, int... ParameterDims>
-class CovarianceWeightedCostFunction<CostFunctor,
-                                     std::integer_sequence<int, ParameterDims...>>
+class CovarianceWeightedCostFunction<
+    CostFunctor,
+    std::integer_sequence<int, ParameterDims...>>
     : public ceres::SizedCostFunction<CostFunctor::kNumResiduals,
                                       ParameterDims...> {
  public:
@@ -133,7 +134,8 @@ class CovarianceWeightedCostFunction<CostFunctor,
   using CovMat = Eigen::Matrix<double, kNumResiduals, kNumResiduals>;
 
   CovarianceWeightedCostFunction(const CovMat& cov, ceres::CostFunction* cost)
-      : left_sqrt_info_(cov.inverse().llt().matrixL().transpose()), cost_(cost) {}
+      : left_sqrt_info_(cov.inverse().llt().matrixL().transpose()),
+        cost_(cost) {}
 
   bool Evaluate(double const* const* parameters,
                 double* residuals,

--- a/src/colmap/estimators/cost_functions/utils.h
+++ b/src/colmap/estimators/cost_functions/utils.h
@@ -30,8 +30,10 @@
 #pragma once
 
 #include "colmap/util/eigen_alignment.h"
+#include "colmap/util/logging.h"
 
 #include <memory>
+#include <vector>
 
 #include <Eigen/Core>
 #include <ceres/ceres.h>
@@ -116,11 +118,10 @@ auto LastValueParameterPack(Args&&... args) {
 }
 
 // Whitens the residuals and jacobians of an inner cost function with a given
-// covariance. Specialized on the inner parameter dims so that each jacobian
-// block is a fixed-size map. Whitening is linear, so applying it to the
-// evaluated jacobians is equivalent to, and cheaper than, propagating it
-// through autodiff.
-template <class CostFunctor, class ParameterDims>
+// covariance. Whitening is linear, so applying it to the evaluated jacobians
+// is equivalent to, and cheaper than, propagating it through autodiff.
+template <class CostFunctor,
+          class ParameterDims = typename CostFunctor::kParameterDims>
 class CovarianceWeightedCostFunction;
 
 template <class CostFunctor, int... ParameterDims>
@@ -135,7 +136,15 @@ class CovarianceWeightedCostFunction<
 
   CovarianceWeightedCostFunction(const CovMat& cov, ceres::CostFunction* cost)
       : left_sqrt_info_(cov.inverse().llt().matrixL().transpose()),
-        cost_(cost) {}
+        cost_(cost) {
+    // The wrapped cost function need not come from CostFunctor, so a shape
+    // mismatch would run the jacobian maps past the buffers Ceres allocates.
+    THROW_CHECK_EQ(cost_->num_residuals(), kNumResiduals);
+    const std::vector<int32_t> expected_parameter_block_sizes = {
+        ParameterDims...};
+    THROW_CHECK(cost_->parameter_block_sizes() ==
+                expected_parameter_block_sizes);
+  }
 
   bool Evaluate(double const* const* parameters,
                 double* residuals,
@@ -165,9 +174,8 @@ class CovarianceWeightedCostFunction<
         .applyOnTheLeft(left_sqrt_info_);
   }
 
-  // Expands the index and the dimension packs in parallel, so that each
-  // dimension is a template argument rather than a lookup into a static
-  // constexpr array, which clang rejects in a constant expression here.
+  // Expands the index and dimension packs in parallel. Indexing a static
+  // constexpr array here instead is rejected by clang.
   template <size_t... kIndices>
   void WhitenJacobians(double** jacobians,
                        std::index_sequence<kIndices...>) const {
@@ -178,9 +186,8 @@ class CovarianceWeightedCostFunction<
   const std::unique_ptr<ceres::CostFunction> cost_;
 };
 
-// Creates a cost function that whitens the given cost functor with a
-// covariance. For example, to weight the reprojection error with an image
-// measurement covariance, one can wrap it as:
+// Whitens the given cost functor with a covariance. For example, to weight
+// the reprojection error with an image measurement covariance:
 //
 //    using ReprojCostFunctor = ReprojErrorCostFunctor<PinholeCameraModel>;
 //    ceres::CostFunction* cost_function =
@@ -197,21 +204,19 @@ class CovarianceWeightedCostFunctor {
 
   template <typename... Args>
   static ceres::CostFunction* Create(const CovMat& cov, Args&&... args) {
-    return new CovarianceWeightedCostFunction<CostFunctor, kParameterDims>(
+    return new CovarianceWeightedCostFunction<CostFunctor>(
         cov,
         CreateAutoDiffCostFunction(
             new CostFunctor(std::forward<Args>(args)...)));
   }
 };
 
-// A cost function wrapper that whitens residuals with per-residual standard
-// deviations, broadcasting a single one over all residuals. Equivalent to
-// CovarianceWeightedCostFunctor with a diagonal covariance, but avoids its
-// inverse, Cholesky factorization, and dense product on every evaluation.
-// Unlike the covariance case, whitening a diagonal through autodiff is as
-// cheap as applying it to the evaluated jacobians, so this stays a functor.
-// For example, to weight the reprojection error with isotropic image
-// measurement noise, one can wrap it as:
+// Whitens residuals with per-residual standard deviations, broadcasting a
+// single one over all residuals. Equivalent to CovarianceWeightedCostFunctor
+// with a diagonal covariance, but avoids its inverse, Cholesky factorization,
+// and dense product. A diagonal is as cheap through autodiff as applied to the
+// evaluated jacobians, so this stays a functor. For example, to weight the
+// reprojection error with isotropic image measurement noise:
 //
 //    using ReprojCostFunctor = ReprojErrorCostFunctor<PinholeCameraModel>;
 //    ceres::CostFunction* cost_function =

--- a/src/colmap/estimators/cost_functions/utils.h
+++ b/src/colmap/estimators/cost_functions/utils.h
@@ -153,14 +153,11 @@ class CovarianceWeightedCostFunction<
   }
 
  private:
-  static constexpr int kParameterDimsArray[] = {ParameterDims...};
-
-  template <size_t kIndex>
+  template <size_t kIndex, int kDim>
   void WhitenJacobian(double** jacobians) const {
     if (jacobians[kIndex] == nullptr) {
       return;
     }
-    constexpr int kDim = kParameterDimsArray[kIndex];
     // Eigen requires single-column matrices to be column major.
     constexpr int kOptions = kDim == 1 ? Eigen::ColMajor : Eigen::RowMajor;
     Eigen::Map<Eigen::Matrix<double, kNumResiduals, kDim, kOptions>>(
@@ -168,10 +165,13 @@ class CovarianceWeightedCostFunction<
         .applyOnTheLeft(left_sqrt_info_);
   }
 
+  // Expands the index and the dimension packs in parallel, so that each
+  // dimension is a template argument rather than a lookup into a static
+  // constexpr array, which clang rejects in a constant expression here.
   template <size_t... kIndices>
   void WhitenJacobians(double** jacobians,
                        std::index_sequence<kIndices...>) const {
-    (WhitenJacobian<kIndices>(jacobians), ...);
+    (WhitenJacobian<kIndices, ParameterDims>(jacobians), ...);
   }
 
   const CovMat left_sqrt_info_;

--- a/src/colmap/estimators/cost_functions/utils.h
+++ b/src/colmap/estimators/cost_functions/utils.h
@@ -34,6 +34,8 @@
 #include <Eigen/Core>
 #include <ceres/ceres.h>
 
+#include <memory>
+
 namespace colmap {
 
 template <typename CostFunctor, int kNumResiduals, int... kParameterDims>
@@ -113,9 +115,70 @@ auto LastValueParameterPack(Args&&... args) {
   return std::get<sizeof...(Args) - 1>(std::forward_as_tuple(args...));
 }
 
-// A cost function wrapper that whitens residuals with a given covariance.
-// For example, to weight the reprojection error with an image measurement
-// covariance, one can wrap it as:
+// Whitens the residuals and jacobians of an inner cost function with a given
+// covariance. Specialized on the inner parameter dims so that each jacobian
+// block is a fixed-size map. Whitening is linear, so applying it to the
+// evaluated jacobians is equivalent to, and cheaper than, propagating it
+// through autodiff.
+template <class CostFunctor, class ParameterDims>
+class CovarianceWeightedCostFunction;
+
+template <class CostFunctor, int... ParameterDims>
+class CovarianceWeightedCostFunction<CostFunctor,
+                                     std::integer_sequence<int, ParameterDims...>>
+    : public ceres::SizedCostFunction<CostFunctor::kNumResiduals,
+                                      ParameterDims...> {
+ public:
+  static constexpr int kNumResiduals = CostFunctor::kNumResiduals;
+  using CovMat = Eigen::Matrix<double, kNumResiduals, kNumResiduals>;
+
+  CovarianceWeightedCostFunction(const CovMat& cov, ceres::CostFunction* cost)
+      : left_sqrt_info_(cov.inverse().llt().matrixL().transpose()), cost_(cost) {}
+
+  bool Evaluate(double const* const* parameters,
+                double* residuals,
+                double** jacobians) const override {
+    if (!cost_->Evaluate(parameters, residuals, jacobians)) {
+      return false;
+    }
+    Eigen::Map<Eigen::Matrix<double, kNumResiduals, 1>>(residuals)
+        .applyOnTheLeft(left_sqrt_info_);
+    if (jacobians != nullptr) {
+      WhitenJacobians(jacobians,
+                      std::make_index_sequence<sizeof...(ParameterDims)>{});
+    }
+    return true;
+  }
+
+ private:
+  static constexpr int kParameterDimsArray[] = {ParameterDims...};
+
+  template <size_t kIndex>
+  void WhitenJacobian(double** jacobians) const {
+    if (jacobians[kIndex] == nullptr) {
+      return;
+    }
+    constexpr int kDim = kParameterDimsArray[kIndex];
+    // Eigen requires single-column matrices to be column major.
+    constexpr int kOptions = kDim == 1 ? Eigen::ColMajor : Eigen::RowMajor;
+    Eigen::Map<Eigen::Matrix<double, kNumResiduals, kDim, kOptions>>(
+        jacobians[kIndex])
+        .applyOnTheLeft(left_sqrt_info_);
+  }
+
+  template <size_t... kIndices>
+  void WhitenJacobians(double** jacobians,
+                       std::index_sequence<kIndices...>) const {
+    (WhitenJacobian<kIndices>(jacobians), ...);
+  }
+
+  const CovMat left_sqrt_info_;
+  const std::unique_ptr<ceres::CostFunction> cost_;
+};
+
+// Creates a cost function that whitens the given cost functor with a
+// covariance. For example, to weight the reprojection error with an image
+// measurement covariance, one can wrap it as:
 //
 //    using ReprojCostFunctor = ReprojErrorCostFunctor<PinholeCameraModel>;
 //    ceres::CostFunction* cost_function =
@@ -131,45 +194,20 @@ class CovarianceWeightedCostFunctor {
   using CovMat = Eigen::Matrix<double, kNumResiduals, kNumResiduals>;
 
   template <typename... Args>
-  explicit CovarianceWeightedCostFunctor(const CovMat& cov, Args&&... args)
-      : left_sqrt_info_(LeftSqrtInformation(cov)),
-        cost_(std::forward<Args>(args)...) {}
-
-  template <typename... Args>
   static ceres::CostFunction* Create(const CovMat& cov, Args&&... args) {
-    return CreateAutoDiffCostFunction(
-        new CovarianceWeightedCostFunctor<CostFunctor>(
-            cov, std::forward<Args>(args)...));
+    return new CovarianceWeightedCostFunction<CostFunctor, kParameterDims>(
+        cov,
+        CreateAutoDiffCostFunction(
+            new CostFunctor(std::forward<Args>(args)...)));
   }
-
-  template <typename... Args>
-  bool operator()(Args... args) const {
-    if (!cost_(args...)) {
-      return false;
-    }
-
-    auto residuals_ptr = LastValueParameterPack(args...);
-    using T = typename std::remove_reference<decltype(*residuals_ptr)>::type;
-    Eigen::Map<Eigen::Matrix<T, kNumResiduals, 1>> residuals(residuals_ptr);
-    // Ceres defines mixed Jet/scalar traits, so keeping the weight in double
-    // avoids materializing an N x N matrix of Jets with all-zero derivatives.
-    residuals.applyOnTheLeft(left_sqrt_info_);
-    return true;
-  }
-
- private:
-  CovMat LeftSqrtInformation(const CovMat& cov) {
-    return cov.inverse().llt().matrixL().transpose();
-  }
-
-  const CovMat left_sqrt_info_;
-  const CostFunctor cost_;
 };
 
 // A cost function wrapper that whitens residuals with per-residual standard
 // deviations, broadcasting a single one over all residuals. Equivalent to
 // CovarianceWeightedCostFunctor with a diagonal covariance, but avoids its
 // inverse, Cholesky factorization, and dense product on every evaluation.
+// Unlike the covariance case, whitening a diagonal through autodiff is as
+// cheap as applying it to the evaluated jacobians, so this stays a functor.
 // For example, to weight the reprojection error with isotropic image
 // measurement noise, one can wrap it as:
 //

--- a/src/colmap/estimators/cost_functions/utils.h
+++ b/src/colmap/estimators/cost_functions/utils.h
@@ -211,11 +211,79 @@ class CovarianceWeightedCostFunctor {
   }
 };
 
-// Whitens residuals with per-residual standard deviations, broadcasting a
-// single one over all residuals. Equivalent to CovarianceWeightedCostFunctor
-// with a diagonal covariance, but avoids its inverse, Cholesky factorization,
-// and dense product. A diagonal is as cheap through autodiff as applied to the
-// evaluated jacobians, so this stays a functor. For example, to weight the
+// Whitens the residuals and jacobians of an inner cost function with
+// per-residual standard deviations. The diagonal counterpart of
+// CovarianceWeightedCostFunction.
+template <class CostFunctor,
+          class ParameterDims = typename CostFunctor::kParameterDims>
+class ScaleWeightedCostFunction;
+
+template <class CostFunctor, int... ParameterDims>
+class ScaleWeightedCostFunction<CostFunctor,
+                                std::integer_sequence<int, ParameterDims...>>
+    : public ceres::SizedCostFunction<CostFunctor::kNumResiduals,
+                                      ParameterDims...> {
+ public:
+  static constexpr int kNumResiduals = CostFunctor::kNumResiduals;
+  using StddevVec = Eigen::Matrix<double, kNumResiduals, 1>;
+
+  ScaleWeightedCostFunction(const StddevVec& stddevs, ceres::CostFunction* cost)
+      : sqrt_info_(stddevs.cwiseInverse()), cost_(cost) {
+    // The wrapped cost function need not come from CostFunctor, so a shape
+    // mismatch would run the jacobian maps past the buffers Ceres allocates.
+    THROW_CHECK_EQ(cost_->num_residuals(), kNumResiduals);
+    const std::vector<int32_t> expected_parameter_block_sizes = {
+        ParameterDims...};
+    THROW_CHECK(cost_->parameter_block_sizes() ==
+                expected_parameter_block_sizes);
+  }
+
+  bool Evaluate(double const* const* parameters,
+                double* residuals,
+                double** jacobians) const override {
+    if (!cost_->Evaluate(parameters, residuals, jacobians)) {
+      return false;
+    }
+    Eigen::Map<Eigen::Matrix<double, kNumResiduals, 1>> residuals_vec(
+        residuals);
+    residuals_vec.array() *= sqrt_info_.array();
+    if (jacobians != nullptr) {
+      WhitenJacobians(jacobians,
+                      std::make_index_sequence<sizeof...(ParameterDims)>{});
+    }
+    return true;
+  }
+
+ private:
+  template <size_t kIndex, int kDim>
+  void WhitenJacobian(double** jacobians) const {
+    if (jacobians[kIndex] == nullptr) {
+      return;
+    }
+    // Eigen requires single-column matrices to be column major.
+    constexpr int kOptions = kDim == 1 ? Eigen::ColMajor : Eigen::RowMajor;
+    Eigen::Map<Eigen::Matrix<double, kNumResiduals, kDim, kOptions>> jacobian(
+        jacobians[kIndex]);
+    jacobian.array().colwise() *= sqrt_info_.array();
+  }
+
+  // Expands the index and dimension packs in parallel. Indexing a static
+  // constexpr array here instead is rejected by clang.
+  template <size_t... kIndices>
+  void WhitenJacobians(double** jacobians,
+                       std::index_sequence<kIndices...>) const {
+    (WhitenJacobian<kIndices, ParameterDims>(jacobians), ...);
+  }
+
+  // Inverse stddevs, so that evaluation multiplies rather than divides.
+  const StddevVec sqrt_info_;
+  const std::unique_ptr<ceres::CostFunction> cost_;
+};
+
+// Whitens the given cost functor with per-residual standard deviations,
+// broadcasting a single one over all residuals. Whitening a diagonal through
+// autodiff is as cheap as applying it to the evaluated jacobians, so this
+// wraps the functor rather than the cost function. For example, to weight the
 // reprojection error with isotropic image measurement noise:
 //
 //    using ReprojCostFunctor = ReprojErrorCostFunctor<PinholeCameraModel>;
@@ -269,5 +337,32 @@ class ScaleWeightedCostFunctor {
   const StddevVec sqrt_info_;
   const CostFunctor cost_;
 };
+
+// Wrap an already built cost function, taking ownership of it. Named rather
+// than overloaded on the weight, because for a single residual a 1x1 weight
+// would be ambiguous between a variance and a standard deviation.
+template <class CostFunctor>
+ceres::CostFunction* CreateCovarianceWeightedCostFunction(
+    const Eigen::Matrix<double,
+                        CostFunctor::kNumResiduals,
+                        CostFunctor::kNumResiduals>& covariance,
+    ceres::CostFunction* cost) {
+  return new CovarianceWeightedCostFunction<CostFunctor>(covariance, cost);
+}
+
+template <class CostFunctor>
+ceres::CostFunction* CreateScaleWeightedCostFunction(
+    const Eigen::Matrix<double, CostFunctor::kNumResiduals, 1>& stddevs,
+    ceres::CostFunction* cost) {
+  return new ScaleWeightedCostFunction<CostFunctor>(stddevs, cost);
+}
+
+template <class CostFunctor>
+ceres::CostFunction* CreateScaleWeightedCostFunction(
+    double stddev, ceres::CostFunction* cost) {
+  return CreateScaleWeightedCostFunction<CostFunctor>(
+      Eigen::Matrix<double, CostFunctor::kNumResiduals, 1>::Constant(stddev),
+      cost);
+}
 
 }  // namespace colmap

--- a/src/colmap/estimators/cost_functions/utils.h
+++ b/src/colmap/estimators/cost_functions/utils.h
@@ -151,7 +151,9 @@ class CovarianceWeightedCostFunctor {
     auto residuals_ptr = LastValueParameterPack(args...);
     using T = typename std::remove_reference<decltype(*residuals_ptr)>::type;
     Eigen::Map<Eigen::Matrix<T, kNumResiduals, 1>> residuals(residuals_ptr);
-    residuals.applyOnTheLeft(left_sqrt_info_.template cast<T>());
+    // Ceres defines mixed Jet/scalar traits, so keeping the weight in double
+    // avoids materializing an N x N matrix of Jets with all-zero derivatives.
+    residuals.applyOnTheLeft(left_sqrt_info_);
     return true;
   }
 
@@ -161,6 +163,65 @@ class CovarianceWeightedCostFunctor {
   }
 
   const CovMat left_sqrt_info_;
+  const CostFunctor cost_;
+};
+
+// A cost function wrapper that whitens residuals with per-residual standard
+// deviations, broadcasting a single one over all residuals. Equivalent to
+// CovarianceWeightedCostFunctor with a diagonal covariance, but avoids its
+// inverse, Cholesky factorization, and dense product on every evaluation.
+// For example, to weight the reprojection error with isotropic image
+// measurement noise, one can wrap it as:
+//
+//    using ReprojCostFunctor = ReprojErrorCostFunctor<PinholeCameraModel>;
+//    ceres::CostFunction* cost_function =
+//        ScaleWeightedCostFunctor<ReprojCostFunctor>::Create(stddev, point2D);
+template <class CostFunctor>
+class ScaleWeightedCostFunctor {
+ public:
+  static constexpr int kNumResiduals = CostFunctor::kNumResiduals;
+  using kParameterDims = typename CostFunctor::kParameterDims;
+
+  using StddevVec = Eigen::Matrix<double, kNumResiduals, 1>;
+
+  template <typename... Args>
+  explicit ScaleWeightedCostFunctor(const StddevVec& stddevs, Args&&... args)
+      : sqrt_info_(stddevs.cwiseInverse()),
+        cost_(std::forward<Args>(args)...) {}
+
+  template <typename... Args>
+  explicit ScaleWeightedCostFunctor(double stddev, Args&&... args)
+      : sqrt_info_(StddevVec::Constant(1.0 / stddev)),
+        cost_(std::forward<Args>(args)...) {}
+
+  template <typename... Args>
+  static ceres::CostFunction* Create(const StddevVec& stddevs, Args&&... args) {
+    return CreateAutoDiffCostFunction(new ScaleWeightedCostFunctor<CostFunctor>(
+        stddevs, std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static ceres::CostFunction* Create(double stddev, Args&&... args) {
+    return CreateAutoDiffCostFunction(new ScaleWeightedCostFunctor<CostFunctor>(
+        stddev, std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  bool operator()(Args... args) const {
+    if (!cost_(args...)) {
+      return false;
+    }
+
+    auto residuals_ptr = LastValueParameterPack(args...);
+    using T = typename std::remove_reference<decltype(*residuals_ptr)>::type;
+    Eigen::Map<Eigen::Matrix<T, kNumResiduals, 1>> residuals(residuals_ptr);
+    residuals.array() *= sqrt_info_.array();
+    return true;
+  }
+
+ private:
+  // Inverse stddevs, so that evaluation multiplies rather than divides.
+  const StddevVec sqrt_info_;
   const CostFunctor cost_;
 };
 

--- a/src/colmap/estimators/cost_functions/utils_test.cc
+++ b/src/colmap/estimators/cost_functions/utils_test.cc
@@ -157,7 +157,7 @@ TEST(ScaleWeightedCostFunctor, MatchesCovarianceWeighted) {
 
   std::unique_ptr<ceres::CostFunction> scale_cost_function(
       ScaleWeightedCostFunctor<NormalPriorCostFunctor<3>>::Create(stddevs,
-                                                                 prior));
+                                                                  prior));
   std::unique_ptr<ceres::CostFunction> cov_cost_function(
       CovarianceWeightedCostFunctor<NormalPriorCostFunctor<3>>::Create(
           stddevs.cwiseAbs2().asDiagonal(), prior));

--- a/src/colmap/estimators/cost_functions/utils_test.cc
+++ b/src/colmap/estimators/cost_functions/utils_test.cc
@@ -118,5 +118,65 @@ TEST(CovarianceWeightedCostFunctor, NormalErrorCostFunctor) {
                               1e-10));
 }
 
+TEST(ScaleWeightedCostFunctor, NormalPriorCostFunctorStddevVec) {
+  const Eigen::Vector3d prior(1, 2, 3);
+  const Eigen::Vector3d param(4, 5, 6);
+
+  std::unique_ptr<ceres::CostFunction> cost_function(
+      ScaleWeightedCostFunctor<NormalPriorCostFunctor<3>>::Create(
+          Eigen::Vector3d(2.0, 1.0, 0.5), prior));
+
+  Eigen::Vector3d residuals;
+  const double* parameters[1] = {param.data()};
+  EXPECT_TRUE(cost_function->Evaluate(parameters, residuals.data(), nullptr));
+  EXPECT_THAT(residuals,
+              EigenMatrixNear(Eigen::Vector3d((param[0] - prior[0]) / 2.0,
+                                              (param[1] - prior[1]) / 1.0,
+                                              (param[2] - prior[2]) / 0.5),
+                              1e-10));
+}
+
+TEST(ScaleWeightedCostFunctor, NormalErrorCostFunctorSingleStddev) {
+  const Eigen::Vector3d param0(1, 2, 3);
+  const Eigen::Vector3d param1(4, 5, 6);
+
+  std::unique_ptr<ceres::CostFunction> cost_function(
+      ScaleWeightedCostFunctor<NormalErrorCostFunctor<3>>::Create(2.0));
+
+  Eigen::Vector3d residuals;
+  const double* parameters[2] = {param0.data(), param1.data()};
+  EXPECT_TRUE(cost_function->Evaluate(parameters, residuals.data(), nullptr));
+  EXPECT_THAT(residuals,
+              EigenMatrixNear(Eigen::Vector3d((param0 - param1) / 2.0), 1e-10));
+}
+
+TEST(ScaleWeightedCostFunctor, MatchesCovarianceWeighted) {
+  const Eigen::Vector3d prior(1, 2, 3);
+  const Eigen::Vector3d param(4, 5, 6);
+  const Eigen::Vector3d stddevs(2.0, 1.0, 0.5);
+
+  std::unique_ptr<ceres::CostFunction> scale_cost_function(
+      ScaleWeightedCostFunctor<NormalPriorCostFunctor<3>>::Create(stddevs,
+                                                                 prior));
+  std::unique_ptr<ceres::CostFunction> cov_cost_function(
+      CovarianceWeightedCostFunctor<NormalPriorCostFunctor<3>>::Create(
+          stddevs.cwiseAbs2().asDiagonal(), prior));
+
+  const double* parameters[1] = {param.data()};
+  Eigen::Vector3d scale_residuals;
+  Eigen::Vector3d cov_residuals;
+  Eigen::Matrix3d scale_jacobian;
+  Eigen::Matrix3d cov_jacobian;
+  double* scale_jacobians[1] = {scale_jacobian.data()};
+  double* cov_jacobians[1] = {cov_jacobian.data()};
+  EXPECT_TRUE(scale_cost_function->Evaluate(
+      parameters, scale_residuals.data(), scale_jacobians));
+  EXPECT_TRUE(cov_cost_function->Evaluate(
+      parameters, cov_residuals.data(), cov_jacobians));
+
+  EXPECT_THAT(scale_residuals, EigenMatrixNear(cov_residuals, 1e-10));
+  EXPECT_THAT(scale_jacobian, EigenMatrixNear(cov_jacobian, 1e-10));
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/colmap/estimators/cost_functions/utils_test.cc
+++ b/src/colmap/estimators/cost_functions/utils_test.cc
@@ -178,5 +178,64 @@ TEST(ScaleWeightedCostFunctor, MatchesCovarianceWeighted) {
   EXPECT_THAT(scale_jacobian, EigenMatrixNear(cov_jacobian, 1e-10));
 }
 
+// Analytical counterpart of NormalPriorCostFunctor<3>, to check that the
+// wrapper also accepts an inner cost function that computes its own jacobians.
+class AnalyticalNormalPriorCostFunction
+    : public ceres::SizedCostFunction<3, 3> {
+ public:
+  explicit AnalyticalNormalPriorCostFunction(const Eigen::Vector3d& prior)
+      : prior_(prior) {}
+
+  bool Evaluate(double const* const* parameters,
+                double* residuals,
+                double** jacobians) const override {
+    Eigen::Map<Eigen::Vector3d> residuals_vec(residuals);
+    residuals_vec = Eigen::Map<const Eigen::Vector3d>(parameters[0]) - prior_;
+    if (jacobians != nullptr && jacobians[0] != nullptr) {
+      Eigen::Map<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(jacobians[0])
+          .setIdentity();
+    }
+    return true;
+  }
+
+ private:
+  const Eigen::Vector3d prior_;
+};
+
+TEST(CovarianceWeightedCostFunction, WrapsAnalyticalCostFunction) {
+  const Eigen::Vector3d prior(1, 2, 3);
+  const Eigen::Vector3d param(4, 5, 6);
+  Eigen::Matrix3d covariance = Eigen::Matrix3d::Identity();
+  covariance(0, 0) = 4.0;
+
+  std::unique_ptr<ceres::CostFunction> autodiff_cost_function(
+      CovarianceWeightedCostFunctor<NormalPriorCostFunctor<3>>::Create(
+          covariance, prior));
+  std::unique_ptr<ceres::CostFunction> analytical_cost_function(
+      new CovarianceWeightedCostFunction<NormalPriorCostFunctor<3>>(
+          covariance, new AnalyticalNormalPriorCostFunction(prior)));
+
+  const double* parameters[1] = {param.data()};
+  Eigen::Vector3d autodiff_residuals;
+  Eigen::Vector3d analytical_residuals;
+  Eigen::Matrix3d autodiff_jacobian;
+  Eigen::Matrix3d analytical_jacobian;
+  double* autodiff_jacobians[1] = {autodiff_jacobian.data()};
+  double* analytical_jacobians[1] = {analytical_jacobian.data()};
+  EXPECT_TRUE(autodiff_cost_function->Evaluate(
+      parameters, autodiff_residuals.data(), autodiff_jacobians));
+  EXPECT_TRUE(analytical_cost_function->Evaluate(
+      parameters, analytical_residuals.data(), analytical_jacobians));
+
+  EXPECT_THAT(analytical_residuals, EigenMatrixNear(autodiff_residuals, 1e-10));
+  EXPECT_THAT(analytical_jacobian, EigenMatrixNear(autodiff_jacobian, 1e-10));
+
+  // Ceres also calls Evaluate without jacobians.
+  Eigen::Vector3d residuals_only;
+  EXPECT_TRUE(analytical_cost_function->Evaluate(
+      parameters, residuals_only.data(), nullptr));
+  EXPECT_THAT(residuals_only, EigenMatrixNear(autodiff_residuals, 1e-10));
+}
+
 }  // namespace
 }  // namespace colmap

--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -37,6 +37,41 @@ using CovarianceWeightedRigReprojErrorConstantRigCostFunctor =
     CovarianceWeightedCostFunctor<
         RigReprojErrorConstantRigCostFunctor<CameraModel>>;
 
+template <typename CameraModel>
+using ScaleWeightedReprojErrorCostFunctor =
+    ScaleWeightedCostFunctor<ReprojErrorCostFunctor<CameraModel>>;
+
+template <typename CameraModel>
+using ScaleWeightedReprojErrorConstantPoseCostFunctor =
+    ScaleWeightedCostFunctor<ReprojErrorConstantPoseCostFunctor<CameraModel>>;
+
+template <typename CameraModel>
+using ScaleWeightedReprojErrorConstantPoint3DCostFunctor =
+    ScaleWeightedCostFunctor<
+        ReprojErrorConstantPoint3DCostFunctor<CameraModel>>;
+
+template <typename CameraModel>
+using ScaleWeightedRigReprojErrorCostFunctor =
+    ScaleWeightedCostFunctor<RigReprojErrorCostFunctor<CameraModel>>;
+
+template <typename CameraModel>
+using ScaleWeightedRigReprojErrorConstantRigCostFunctor =
+    ScaleWeightedCostFunctor<RigReprojErrorConstantRigCostFunctor<CameraModel>>;
+
+// Create is overloaded on single and per-residual stddevs, so taking its
+// address needs a target signature to disambiguate.
+template <class CostFunctor, typename... Args>
+ceres::CostFunction* (*ScaleCost())(double, Args&&...) {
+  return &ScaleWeightedCostFunctor<CostFunctor>::template Create<Args...>;
+}
+
+template <class CostFunctor, typename... Args>
+ceres::CostFunction* (*ScaleVecCost())(
+    const typename ScaleWeightedCostFunctor<CostFunctor>::StddevVec&,
+    Args&&...) {
+  return &ScaleWeightedCostFunctor<CostFunctor>::template Create<Args...>;
+}
+
 void BindCostFunctions(py::module& m_parent) {
   py::module_ m = m_parent.def_submodule("cost_functions");
   IsPyceresAvailable();  // Try to import pyceres to populate the docstrings.
@@ -55,6 +90,22 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D_cov"_a,
         "point2D"_a,
         "Reprojection error with 2D detection noise.");
+  m.def("ReprojErrorCost",
+        &CreateCameraCostFunction<ScaleWeightedReprojErrorCostFunctor,
+                                  double,
+                                  const Eigen::Vector2d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "Reprojection error with isotropic 2D detection noise.");
+  m.def("ReprojErrorCost",
+        &CreateCameraCostFunction<ScaleWeightedReprojErrorCostFunctor,
+                                  const Eigen::Vector2d&,
+                                  const Eigen::Vector2d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "Reprojection error with per-axis 2D detection noise.");
 
   m.def("ReprojErrorCost",
         &CreateCameraCostFunction<ReprojErrorConstantPoseCostFunctor,
@@ -75,6 +126,30 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "cam_from_world"_a,
         "Reprojection error with constant camera pose and 2D detection noise.");
+  m.def("ReprojErrorCost",
+        &CreateCameraCostFunction<
+            ScaleWeightedReprojErrorConstantPoseCostFunctor,
+            double,
+            const Eigen::Vector2d&,
+            const Rigid3d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "cam_from_world"_a,
+        "Reprojection error with constant camera pose and isotropic 2D "
+        "detection noise.");
+  m.def("ReprojErrorCost",
+        &CreateCameraCostFunction<
+            ScaleWeightedReprojErrorConstantPoseCostFunctor,
+            const Eigen::Vector2d&,
+            const Eigen::Vector2d&,
+            const Rigid3d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "cam_from_world"_a,
+        "Reprojection error with constant camera pose and per-axis 2D "
+        "detection noise.");
 
   m.def("ReprojErrorCost",
         &CreateCameraCostFunction<ReprojErrorConstantPoint3DCostFunctor,
@@ -95,6 +170,30 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "point3D"_a,
         "Reprojection error with constant 3D point and 2D detection noise.");
+  m.def("ReprojErrorCost",
+        &CreateCameraCostFunction<
+            ScaleWeightedReprojErrorConstantPoint3DCostFunctor,
+            double,
+            const Eigen::Vector2d&,
+            const Eigen::Vector3d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "point3D"_a,
+        "Reprojection error with constant 3D point and isotropic 2D detection "
+        "noise.");
+  m.def("ReprojErrorCost",
+        &CreateCameraCostFunction<
+            ScaleWeightedReprojErrorConstantPoint3DCostFunctor,
+            const Eigen::Vector2d&,
+            const Eigen::Vector2d&,
+            const Eigen::Vector3d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "point3D"_a,
+        "Reprojection error with constant 3D point and per-axis 2D detection "
+        "noise.");
 
   m.def("RigReprojErrorCost",
         &CreateCameraCostFunction<RigReprojErrorCostFunctor,
@@ -110,6 +209,22 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D_cov"_a,
         "point2D"_a,
         "Reprojection error for camera rig with 2D detection noise.");
+  m.def("RigReprojErrorCost",
+        &CreateCameraCostFunction<ScaleWeightedRigReprojErrorCostFunctor,
+                                  double,
+                                  const Eigen::Vector2d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "Reprojection error for camera rig with isotropic 2D detection noise.");
+  m.def("RigReprojErrorCost",
+        &CreateCameraCostFunction<ScaleWeightedRigReprojErrorCostFunctor,
+                                  const Eigen::Vector2d&,
+                                  const Eigen::Vector2d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "Reprojection error for camera rig with per-axis 2D detection noise.");
 
   m.def("RigReprojErrorCost",
         &CreateCameraCostFunction<RigReprojErrorConstantRigCostFunctor,
@@ -131,6 +246,30 @@ void BindCostFunctions(py::module& m_parent) {
         "cam_from_rig"_a,
         "Reprojection error for camera rig with constant cam-from-rig pose and "
         "2D detection noise.");
+  m.def("RigReprojErrorCost",
+        &CreateCameraCostFunction<
+            ScaleWeightedRigReprojErrorConstantRigCostFunctor,
+            double,
+            const Eigen::Vector2d&,
+            const Rigid3d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "cam_from_rig"_a,
+        "Reprojection error for camera rig with constant cam-from-rig pose and "
+        "isotropic 2D detection noise.");
+  m.def("RigReprojErrorCost",
+        &CreateCameraCostFunction<
+            ScaleWeightedRigReprojErrorConstantRigCostFunctor,
+            const Eigen::Vector2d&,
+            const Eigen::Vector2d&,
+            const Rigid3d&>,
+        "camera_model_id"_a,
+        "point2D_stddev"_a,
+        "point2D"_a,
+        "cam_from_rig"_a,
+        "Reprojection error for camera rig with constant cam-from-rig pose and "
+        "per-axis 2D detection noise.");
 
   m.def("SampsonErrorCost",
         &SampsonErrorCostFunctor::Create<const Eigen::Vector2d&,
@@ -149,6 +288,18 @@ void BindCostFunctions(py::module& m_parent) {
         "cam_cov_from_world_prior"_a,
         "cam_from_world_prior"_a,
         "6-DoF error on the absolute camera pose with prior covariance.");
+  m.def("AbsolutePosePriorCost",
+        ScaleCost<AbsolutePosePriorCostFunctor, const Rigid3d&>(),
+        "cam_stddev_from_world_prior"_a,
+        "cam_from_world_prior"_a,
+        "6-DoF error on the absolute camera pose with isotropic prior "
+        "standard deviation.");
+  m.def("AbsolutePosePriorCost",
+        ScaleVecCost<AbsolutePosePriorCostFunctor, const Rigid3d&>(),
+        "cam_stddev_from_world_prior"_a,
+        "cam_from_world_prior"_a,
+        "6-DoF error on the absolute camera pose with per-DoF prior standard "
+        "deviations.");
 
   m.def("AbsolutePosePositionPriorCost",
         &AbsolutePosePositionPriorCostFunctor::Create<const Eigen::Vector3d&>,
@@ -162,6 +313,20 @@ void BindCostFunctions(py::module& m_parent) {
       "position_in_world_prior"_a,
       "3-DoF error on the absolute camera pose's position with prior "
       "covariance.");
+  m.def("AbsolutePosePositionPriorCost",
+        ScaleCost<AbsolutePosePositionPriorCostFunctor,
+                  const Eigen::Vector3d&>(),
+        "position_stddev_in_world_prior"_a,
+        "position_in_world_prior"_a,
+        "3-DoF error on the absolute camera pose's position with isotropic "
+        "prior standard deviation.");
+  m.def("AbsolutePosePositionPriorCost",
+        ScaleVecCost<AbsolutePosePositionPriorCostFunctor,
+                     const Eigen::Vector3d&>(),
+        "position_stddev_in_world_prior"_a,
+        "position_in_world_prior"_a,
+        "3-DoF error on the absolute camera pose's position with per-axis "
+        "prior standard deviations.");
 
   m.def("RelativePosePriorCost",
         &RelativePosePriorCostFunctor::Create<const Rigid3d&>,
@@ -175,6 +340,18 @@ void BindCostFunctions(py::module& m_parent) {
         "i_from_j_prior"_a,
         "6-DoF error between two absolute camera poses based on a prior "
         "relative pose with prior covariance.");
+  m.def("RelativePosePriorCost",
+        ScaleCost<RelativePosePriorCostFunctor, const Rigid3d&>(),
+        "i_stddev_from_j_prior"_a,
+        "i_from_j_prior"_a,
+        "6-DoF error between two absolute camera poses based on a prior "
+        "relative pose with isotropic prior standard deviation.");
+  m.def("RelativePosePriorCost",
+        ScaleVecCost<RelativePosePriorCostFunctor, const Rigid3d&>(),
+        "i_stddev_from_j_prior"_a,
+        "i_from_j_prior"_a,
+        "6-DoF error between two absolute camera poses based on a prior "
+        "relative pose with per-DoF prior standard deviations.");
 
   m.def("Point3DAlignmentCost",
         &Point3DAlignmentCostFunctor::Create<const Eigen::Vector3d&, bool>,
@@ -189,4 +366,20 @@ void BindCostFunctions(py::module& m_parent) {
         "use_log_scale"_a = true,
         "Error between 3D points transformed by a 3D similarity transform. "
         "with prior covariance");
+  m.def("Point3DAlignmentCost",
+        ScaleCost<Point3DAlignmentCostFunctor, const Eigen::Vector3d&, bool>(),
+        "point_stddev_in_b_prior"_a,
+        "point_in_b_prior"_a,
+        "use_log_scale"_a = true,
+        "Error between 3D points transformed by a 3D similarity transform, "
+        "with an isotropic prior standard deviation.");
+  m.def("Point3DAlignmentCost",
+        ScaleVecCost<Point3DAlignmentCostFunctor,
+                     const Eigen::Vector3d&,
+                     bool>(),
+        "point_stddev_in_b_prior"_a,
+        "point_in_b_prior"_a,
+        "use_log_scale"_a = true,
+        "Error between 3D points transformed by a 3D similarity transform, "
+        "with per-axis prior standard deviations.");
 }

--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -245,17 +245,12 @@ void BindCostFunctions(py::module& m_parent) {
         "cam_from_world_prior"_a,
         "6-DoF error on the absolute camera pose with prior covariance.");
   m.def("AbsolutePosePriorCost",
-        ScaleCost<AbsolutePosePriorCostFunctor, const Rigid3d&>(),
-        "cam_stddev_from_world_prior"_a,
-        "cam_from_world_prior"_a,
-        "6-DoF error on the absolute camera pose with isotropic prior "
-        "standard deviation.");
-  m.def("AbsolutePosePriorCost",
         ScaleVecCost<AbsolutePosePriorCostFunctor, const Rigid3d&>(),
-        "cam_stddev_from_world_prior"_a,
+        "cam_from_world_prior_stddevs"_a,
         "cam_from_world_prior"_a,
         "6-DoF error on the absolute camera pose with per-DoF prior standard "
-        "deviations.");
+        "deviations. The first three are on the rotation and the last three on "
+        "the translation, so they do not share a unit.");
 
   m.def("AbsolutePosePositionPriorCost",
         &AbsolutePosePositionPriorCostFunctor::Create<const Eigen::Vector3d&>,
@@ -297,17 +292,13 @@ void BindCostFunctions(py::module& m_parent) {
         "6-DoF error between two absolute camera poses based on a prior "
         "relative pose with prior covariance.");
   m.def("RelativePosePriorCost",
-        ScaleCost<RelativePosePriorCostFunctor, const Rigid3d&>(),
-        "i_stddev_from_j_prior"_a,
-        "i_from_j_prior"_a,
-        "6-DoF error between two absolute camera poses based on a prior "
-        "relative pose with isotropic prior standard deviation.");
-  m.def("RelativePosePriorCost",
         ScaleVecCost<RelativePosePriorCostFunctor, const Rigid3d&>(),
-        "i_stddev_from_j_prior"_a,
+        "i_from_j_prior_stddevs"_a,
         "i_from_j_prior"_a,
         "6-DoF error between two absolute camera poses based on a prior "
-        "relative pose with per-DoF prior standard deviations.");
+        "relative pose with per-DoF prior standard deviations. The first three "
+        "are on the rotation and the last three on the translation, so they do "
+        "not share a unit.");
 
   m.def("Point3DAlignmentCost",
         &Point3DAlignmentCostFunctor::Create<const Eigen::Vector3d&, bool>,

--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -14,50 +14,6 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-template <typename CameraModel>
-using CovarianceWeightedReprojErrorCostFunctor =
-    CovarianceWeightedCostFunctor<ReprojErrorCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using CovarianceWeightedReprojErrorConstantPoseCostFunctor =
-    CovarianceWeightedCostFunctor<
-        ReprojErrorConstantPoseCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using CovarianceWeightedReprojErrorConstantPoint3DCostFunctor =
-    CovarianceWeightedCostFunctor<
-        ReprojErrorConstantPoint3DCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using CovarianceWeightedRigReprojErrorCostFunctor =
-    CovarianceWeightedCostFunctor<RigReprojErrorCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using CovarianceWeightedRigReprojErrorConstantRigCostFunctor =
-    CovarianceWeightedCostFunctor<
-        RigReprojErrorConstantRigCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using ScaleWeightedReprojErrorCostFunctor =
-    ScaleWeightedCostFunctor<ReprojErrorCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using ScaleWeightedReprojErrorConstantPoseCostFunctor =
-    ScaleWeightedCostFunctor<ReprojErrorConstantPoseCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using ScaleWeightedReprojErrorConstantPoint3DCostFunctor =
-    ScaleWeightedCostFunctor<
-        ReprojErrorConstantPoint3DCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using ScaleWeightedRigReprojErrorCostFunctor =
-    ScaleWeightedCostFunctor<RigReprojErrorCostFunctor<CameraModel>>;
-
-template <typename CameraModel>
-using ScaleWeightedRigReprojErrorConstantRigCostFunctor =
-    ScaleWeightedCostFunctor<RigReprojErrorConstantRigCostFunctor<CameraModel>>;
-
 // Create is overloaded on single and per-residual stddevs, so taking its
 // address needs a target signature to disambiguate.
 template <class CostFunctor, typename... Args>
@@ -83,25 +39,25 @@ void BindCostFunctions(py::module& m_parent) {
       "point2D"_a,
       "Reprojection error.");
   m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<CovarianceWeightedReprojErrorCostFunctor,
-                                  const Eigen::Matrix2d&,
-                                  const Eigen::Vector2d&>,
+        &CreateCovarianceWeightedCameraCostFunction<ReprojErrorCostFunctor,
+                                                    Eigen::Matrix2d,
+                                                    const Eigen::Vector2d&>,
         "camera_model_id"_a,
         "point2D_cov"_a,
         "point2D"_a,
         "Reprojection error with 2D detection noise.");
   m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<ScaleWeightedReprojErrorCostFunctor,
-                                  double,
-                                  const Eigen::Vector2d&>,
+        &CreateScaleWeightedCameraCostFunction<ReprojErrorCostFunctor,
+                                               double,
+                                               const Eigen::Vector2d&>,
         "camera_model_id"_a,
         "point2D_stddev"_a,
         "point2D"_a,
         "Reprojection error with isotropic 2D detection noise.");
   m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<ScaleWeightedReprojErrorCostFunctor,
-                                  const Eigen::Vector2d&,
-                                  const Eigen::Vector2d&>,
+        &CreateScaleWeightedCameraCostFunction<ReprojErrorCostFunctor,
+                                               Eigen::Vector2d,
+                                               const Eigen::Vector2d&>,
         "camera_model_id"_a,
         "point2D_stddev"_a,
         "point2D"_a,
@@ -116,9 +72,9 @@ void BindCostFunctions(py::module& m_parent) {
         "cam_from_world"_a,
         "Reprojection error with constant camera pose.");
   m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<
-            CovarianceWeightedReprojErrorConstantPoseCostFunctor,
-            const Eigen::Matrix2d&,
+        &CreateCovarianceWeightedCameraCostFunction<
+            ReprojErrorConstantPoseCostFunctor,
+            Eigen::Matrix2d,
             const Eigen::Vector2d&,
             const Rigid3d&>,
         "camera_model_id"_a,
@@ -128,10 +84,10 @@ void BindCostFunctions(py::module& m_parent) {
         "Reprojection error with constant camera pose and 2D detection noise.");
   m.def(
       "ReprojErrorCost",
-      &CreateCameraCostFunction<ScaleWeightedReprojErrorConstantPoseCostFunctor,
-                                double,
-                                const Eigen::Vector2d&,
-                                const Rigid3d&>,
+      &CreateScaleWeightedCameraCostFunction<ReprojErrorConstantPoseCostFunctor,
+                                             double,
+                                             const Eigen::Vector2d&,
+                                             const Rigid3d&>,
       "camera_model_id"_a,
       "point2D_stddev"_a,
       "point2D"_a,
@@ -140,10 +96,10 @@ void BindCostFunctions(py::module& m_parent) {
       "detection noise.");
   m.def(
       "ReprojErrorCost",
-      &CreateCameraCostFunction<ScaleWeightedReprojErrorConstantPoseCostFunctor,
-                                const Eigen::Vector2d&,
-                                const Eigen::Vector2d&,
-                                const Rigid3d&>,
+      &CreateScaleWeightedCameraCostFunction<ReprojErrorConstantPoseCostFunctor,
+                                             Eigen::Vector2d,
+                                             const Eigen::Vector2d&,
+                                             const Rigid3d&>,
       "camera_model_id"_a,
       "point2D_stddev"_a,
       "point2D"_a,
@@ -160,9 +116,9 @@ void BindCostFunctions(py::module& m_parent) {
         "point3D"_a,
         "Reprojection error with constant 3D point.");
   m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<
-            CovarianceWeightedReprojErrorConstantPoint3DCostFunctor,
-            const Eigen::Matrix2d&,
+        &CreateCovarianceWeightedCameraCostFunction<
+            ReprojErrorConstantPoint3DCostFunctor,
+            Eigen::Matrix2d,
             const Eigen::Vector2d&,
             const Eigen::Vector3d&>,
         "camera_model_id"_a,
@@ -171,8 +127,8 @@ void BindCostFunctions(py::module& m_parent) {
         "point3D"_a,
         "Reprojection error with constant 3D point and 2D detection noise.");
   m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<
-            ScaleWeightedReprojErrorConstantPoint3DCostFunctor,
+        &CreateScaleWeightedCameraCostFunction<
+            ReprojErrorConstantPoint3DCostFunctor,
             double,
             const Eigen::Vector2d&,
             const Eigen::Vector3d&>,
@@ -183,9 +139,9 @@ void BindCostFunctions(py::module& m_parent) {
         "Reprojection error with constant 3D point and isotropic 2D detection "
         "noise.");
   m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<
-            ScaleWeightedReprojErrorConstantPoint3DCostFunctor,
-            const Eigen::Vector2d&,
+        &CreateScaleWeightedCameraCostFunction<
+            ReprojErrorConstantPoint3DCostFunctor,
+            Eigen::Vector2d,
             const Eigen::Vector2d&,
             const Eigen::Vector3d&>,
         "camera_model_id"_a,
@@ -202,25 +158,25 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "Reprojection error for camera rig.");
   m.def("RigReprojErrorCost",
-        &CreateCameraCostFunction<CovarianceWeightedRigReprojErrorCostFunctor,
-                                  const Eigen::Matrix2d&,
-                                  const Eigen::Vector2d&>,
+        &CreateCovarianceWeightedCameraCostFunction<RigReprojErrorCostFunctor,
+                                                    Eigen::Matrix2d,
+                                                    const Eigen::Vector2d&>,
         "camera_model_id"_a,
         "point2D_cov"_a,
         "point2D"_a,
         "Reprojection error for camera rig with 2D detection noise.");
   m.def("RigReprojErrorCost",
-        &CreateCameraCostFunction<ScaleWeightedRigReprojErrorCostFunctor,
-                                  double,
-                                  const Eigen::Vector2d&>,
+        &CreateScaleWeightedCameraCostFunction<RigReprojErrorCostFunctor,
+                                               double,
+                                               const Eigen::Vector2d&>,
         "camera_model_id"_a,
         "point2D_stddev"_a,
         "point2D"_a,
         "Reprojection error for camera rig with isotropic 2D detection noise.");
   m.def("RigReprojErrorCost",
-        &CreateCameraCostFunction<ScaleWeightedRigReprojErrorCostFunctor,
-                                  const Eigen::Vector2d&,
-                                  const Eigen::Vector2d&>,
+        &CreateScaleWeightedCameraCostFunction<RigReprojErrorCostFunctor,
+                                               Eigen::Vector2d,
+                                               const Eigen::Vector2d&>,
         "camera_model_id"_a,
         "point2D_stddev"_a,
         "point2D"_a,
@@ -235,9 +191,9 @@ void BindCostFunctions(py::module& m_parent) {
         "cam_from_rig"_a,
         "Reprojection error for camera rig with constant cam-from-rig pose.");
   m.def("RigReprojErrorCost",
-        &CreateCameraCostFunction<
-            CovarianceWeightedRigReprojErrorConstantRigCostFunctor,
-            const Eigen::Matrix2d&,
+        &CreateCovarianceWeightedCameraCostFunction<
+            RigReprojErrorConstantRigCostFunctor,
+            Eigen::Matrix2d,
             const Eigen::Vector2d&,
             const Rigid3d&>,
         "camera_model_id"_a,
@@ -247,8 +203,8 @@ void BindCostFunctions(py::module& m_parent) {
         "Reprojection error for camera rig with constant cam-from-rig pose and "
         "2D detection noise.");
   m.def("RigReprojErrorCost",
-        &CreateCameraCostFunction<
-            ScaleWeightedRigReprojErrorConstantRigCostFunctor,
+        &CreateScaleWeightedCameraCostFunction<
+            RigReprojErrorConstantRigCostFunctor,
             double,
             const Eigen::Vector2d&,
             const Rigid3d&>,
@@ -259,9 +215,9 @@ void BindCostFunctions(py::module& m_parent) {
         "Reprojection error for camera rig with constant cam-from-rig pose and "
         "isotropic 2D detection noise.");
   m.def("RigReprojErrorCost",
-        &CreateCameraCostFunction<
-            ScaleWeightedRigReprojErrorConstantRigCostFunctor,
-            const Eigen::Vector2d&,
+        &CreateScaleWeightedCameraCostFunction<
+            RigReprojErrorConstantRigCostFunctor,
+            Eigen::Vector2d,
             const Eigen::Vector2d&,
             const Rigid3d&>,
         "camera_model_id"_a,

--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -246,7 +246,7 @@ void BindCostFunctions(py::module& m_parent) {
         "6-DoF error on the absolute camera pose with prior covariance.");
   m.def("AbsolutePosePriorCost",
         ScaleVecCost<AbsolutePosePriorCostFunctor, const Rigid3d&>(),
-        "cam_from_world_prior_stddevs"_a,
+        "cam_stddev_from_world_prior"_a,
         "cam_from_world_prior"_a,
         "6-DoF error on the absolute camera pose with per-DoF prior standard "
         "deviations. The first three are on the rotation and the last three on "
@@ -293,7 +293,7 @@ void BindCostFunctions(py::module& m_parent) {
         "relative pose with prior covariance.");
   m.def("RelativePosePriorCost",
         ScaleVecCost<RelativePosePriorCostFunctor, const Rigid3d&>(),
-        "i_from_j_prior_stddevs"_a,
+        "i_stddev_from_j_prior"_a,
         "i_from_j_prior"_a,
         "6-DoF error between two absolute camera poses based on a prior "
         "relative pose with per-DoF prior standard deviations. The first three "

--- a/src/pycolmap/estimators/cost_functions.cc
+++ b/src/pycolmap/estimators/cost_functions.cc
@@ -126,30 +126,30 @@ void BindCostFunctions(py::module& m_parent) {
         "point2D"_a,
         "cam_from_world"_a,
         "Reprojection error with constant camera pose and 2D detection noise.");
-  m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<
-            ScaleWeightedReprojErrorConstantPoseCostFunctor,
-            double,
-            const Eigen::Vector2d&,
-            const Rigid3d&>,
-        "camera_model_id"_a,
-        "point2D_stddev"_a,
-        "point2D"_a,
-        "cam_from_world"_a,
-        "Reprojection error with constant camera pose and isotropic 2D "
-        "detection noise.");
-  m.def("ReprojErrorCost",
-        &CreateCameraCostFunction<
-            ScaleWeightedReprojErrorConstantPoseCostFunctor,
-            const Eigen::Vector2d&,
-            const Eigen::Vector2d&,
-            const Rigid3d&>,
-        "camera_model_id"_a,
-        "point2D_stddev"_a,
-        "point2D"_a,
-        "cam_from_world"_a,
-        "Reprojection error with constant camera pose and per-axis 2D "
-        "detection noise.");
+  m.def(
+      "ReprojErrorCost",
+      &CreateCameraCostFunction<ScaleWeightedReprojErrorConstantPoseCostFunctor,
+                                double,
+                                const Eigen::Vector2d&,
+                                const Rigid3d&>,
+      "camera_model_id"_a,
+      "point2D_stddev"_a,
+      "point2D"_a,
+      "cam_from_world"_a,
+      "Reprojection error with constant camera pose and isotropic 2D "
+      "detection noise.");
+  m.def(
+      "ReprojErrorCost",
+      &CreateCameraCostFunction<ScaleWeightedReprojErrorConstantPoseCostFunctor,
+                                const Eigen::Vector2d&,
+                                const Eigen::Vector2d&,
+                                const Rigid3d&>,
+      "camera_model_id"_a,
+      "point2D_stddev"_a,
+      "point2D"_a,
+      "cam_from_world"_a,
+      "Reprojection error with constant camera pose and per-axis 2D "
+      "detection noise.");
 
   m.def("ReprojErrorCost",
         &CreateCameraCostFunction<ReprojErrorConstantPoint3DCostFunctor,
@@ -313,13 +313,13 @@ void BindCostFunctions(py::module& m_parent) {
       "position_in_world_prior"_a,
       "3-DoF error on the absolute camera pose's position with prior "
       "covariance.");
-  m.def("AbsolutePosePositionPriorCost",
-        ScaleCost<AbsolutePosePositionPriorCostFunctor,
-                  const Eigen::Vector3d&>(),
-        "position_stddev_in_world_prior"_a,
-        "position_in_world_prior"_a,
-        "3-DoF error on the absolute camera pose's position with isotropic "
-        "prior standard deviation.");
+  m.def(
+      "AbsolutePosePositionPriorCost",
+      ScaleCost<AbsolutePosePositionPriorCostFunctor, const Eigen::Vector3d&>(),
+      "position_stddev_in_world_prior"_a,
+      "position_in_world_prior"_a,
+      "3-DoF error on the absolute camera pose's position with isotropic "
+      "prior standard deviation.");
   m.def("AbsolutePosePositionPriorCost",
         ScaleVecCost<AbsolutePosePositionPriorCostFunctor,
                      const Eigen::Vector3d&>(),
@@ -373,13 +373,12 @@ void BindCostFunctions(py::module& m_parent) {
         "use_log_scale"_a = true,
         "Error between 3D points transformed by a 3D similarity transform, "
         "with an isotropic prior standard deviation.");
-  m.def("Point3DAlignmentCost",
-        ScaleVecCost<Point3DAlignmentCostFunctor,
-                     const Eigen::Vector3d&,
-                     bool>(),
-        "point_stddev_in_b_prior"_a,
-        "point_in_b_prior"_a,
-        "use_log_scale"_a = true,
-        "Error between 3D points transformed by a 3D similarity transform, "
-        "with per-axis prior standard deviations.");
+  m.def(
+      "Point3DAlignmentCost",
+      ScaleVecCost<Point3DAlignmentCostFunctor, const Eigen::Vector3d&, bool>(),
+      "point_stddev_in_b_prior"_a,
+      "point_in_b_prior"_a,
+      "use_log_scale"_a = true,
+      "Error between 3D points transformed by a 3D similarity transform, "
+      "with per-axis prior standard deviations.");
 }


### PR DESCRIPTION
Adds `ScaleWeightedCostFunctor`, a sibling of `CovarianceWeightedCostFunctor` that
whitens residuals with standard deviations instead of a full covariance, and
drops a `cast<T>()` from the existing covariance wrapper.

## Motivation

Weighting a cost functor by an isotropic or diagonal uncertainty currently means
constructing `stddev^2 * I` and paying, per residual block, a matrix inverse and
a Cholesky factorization at setup plus a dense `N x N` product on every
evaluation. That is the common case in tree: `AbsolutePoseRefinementOptions::
position_prior_covariance` defaults to identity, and the bundle adjustment pose
prior falls back to `prior_position_fallback_stddev^2 * I`.

`ceres::ScaledLoss` is not a substitute when a robust loss is attached. It forms
`a * rho(s)`, whereas whitening forms `rho(s / sigma^2)`, so the inlier/outlier
knee sits at `delta` regardless of `a` rather than scaling with `sigma`. It also
requires one heap loss object per distinct weight, since every problem here sets
`loss_function_ownership = DO_NOT_TAKE_OWNERSHIP`.

## Changes

- `ScaleWeightedCostFunctor<CostFunctor>`, taking either a per-residual vector
  of standard deviations or a single one broadcast over all residuals.
  `Create(stddev, ...)` produces exactly the same residuals and jacobians as
  `CovarianceWeightedCostFunctor::Create(stddev * stddev * I, ...)`. The
  reciprocal is taken once in the constructor, so the hot path multiplies.
- `CovarianceWeightedCostFunctor` now applies `left_sqrt_info_` as a `double`
  matrix. Ceres defines mixed `Jet`/scalar operator traits, so the previous
  `cast<T>()` was materializing an `N x N` matrix of Jets and multiplying their
  all-zero derivative parts. Results are bit-identical, no call site changes.
- pycolmap bindings for both forms on every functor that already has a
  covariance overload: `ReprojErrorCost`, the constant-pose and
  constant-3D-point variants, `RigReprojErrorCost` and its constant-rig
  variant, `AbsolutePosePriorCost`, `AbsolutePosePositionPriorCost`,
  `RelativePosePriorCost` and `Point3DAlignmentCost`. A float selects the
  isotropic overload and an array of per-residual standard deviations the
  diagonal one.
- Tests covering the standard deviation vector, the broadcast scalar, and
  equivalence with the covariance wrapper on both residuals and jacobians.

## Runtime

Release, `-O3 -march=native`, pinned to one core, best of 5 runs of 2M
`Evaluate()` calls with jacobians.

| cost functor | unweighted | Covariance (before) | Covariance (after) | Scale |
|---|---|---|---|---|
| `ReprojErrorCostFunctor<Pinhole>` (N=2, 14 params) | 345.2 ns | 400.3 ns | 401.8 ns | 351.1 ns |
| `AbsolutePosePositionPriorCostFunctor` (N=3, 7 params) | 353.5 ns | 474.5 ns | 450.2 ns | 363.2 ns |
| `AbsolutePosePriorCostFunctor` (N=6, 7 params) | 453.0 ns | 864.2 ns | 756.7 ns | 468.2 ns |

**Whitening overhead drops from +16% / +34% / +91% to +2% / +3% / +3%, and
removing the cast alone recovers 5% at N=3 and 12% at N=6 for callers that need
a full covariance.** The cast makes no difference at N=2, where the temporary is
a single 2x2 block.
