### PR TITLE
Refactor `BundleAdjustmentController` to take `BundleAdjustmentConfig` directly

### DIFF
--- a/src/colmap/controllers/bundle_adjustment.cc
+++ b/src/colmap/controllers/bundle_adjustment.cc
@@ -29,16 +29,37 @@
 
 #include "colmap/controllers/bundle_adjustment.h"
 
-#include "colmap/estimators/bundle_adjustment_ceres.h"
 #include "colmap/sfm/observation_manager.h"
+#include "colmap/util/logging.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/timer.h"
 
 namespace colmap {
+
 BundleAdjustmentController::BundleAdjustmentController(
-    const OptionManager& options,
-    std::shared_ptr<Reconstruction> reconstruction)
-    : options_(options), reconstruction_(std::move(reconstruction)) {}
+    const BundleAdjustmentOptions& ba_options,
+    const BundleAdjustmentConfig& ba_config,
+    std::shared_ptr<class Reconstruction> reconstruction)
+    : ba_options_(ba_options),
+      ba_config_(ba_config),
+      reconstruction_(std::move(THROW_CHECK_NOTNULL(reconstruction))) {
+  THROW_CHECK(ba_options_.Check());
+}
+
+BundleAdjustmentController::BundleAdjustmentController(
+    const BundleAdjustmentOptions& ba_options,
+    const BundleAdjustmentConfig& ba_config,
+    const PosePriorBundleAdjustmentOptions& prior_options,
+    std::vector<PosePrior> pose_priors,
+    std::shared_ptr<class Reconstruction> reconstruction)
+    : ba_options_(ba_options),
+      ba_config_(ba_config),
+      prior_options_(prior_options),
+      pose_priors_(std::move(pose_priors)),
+      reconstruction_(std::move(THROW_CHECK_NOTNULL(reconstruction))) {
+  THROW_CHECK(ba_options_.Check());
+  THROW_CHECK(prior_options_->Check());
+}
 
 void BundleAdjustmentController::Run() {
   THROW_CHECK_NOTNULL(reconstruction_);
@@ -54,28 +75,39 @@ void BundleAdjustmentController::Run() {
   if (CheckIfStopped()) {
     return;
   }
+  if (ba_config_.NumImages() < 2 && ba_config_.NumVariablePoints() == 0) {
+    LOG(WARNING) << "At least two images must be registered for global "
+                    "bundle adjustment";
+    return;
+  }
 
   // Avoid degeneracies in bundle adjustment.
   ObservationManager(*reconstruction_).FilterObservationsWithNegativeDepth();
 
-  BundleAdjustmentOptions ba_options = *options_.bundle_adjustment;
+  BundleAdjustmentOptions ba_options = ba_options_;
   ba_options.check_if_stopped = [this]() { return CheckIfStopped(); };
+  BundleAdjustmentConfig ba_config = ba_config_;
 
-  // Configure bundle adjustment.
-  BundleAdjustmentConfig ba_config;
-  for (const image_t image_id : reconstruction_->RegImageIds()) {
-    ba_config.AddImage(image_id);
+  std::unique_ptr<BundleAdjuster> bundle_adjuster;
+  const bool use_pose_prior_ba =
+      prior_options_.has_value() && pose_priors_.has_value();
+  if (use_pose_prior_ba) {
+    bundle_adjuster = CreatePosePriorBundleAdjuster(ba_options,
+                                                    *prior_options_,
+                                                    ba_config,
+                                                    *pose_priors_,
+                                                    *reconstruction_);
+  } else {
+    if (ba_config.FixedGauge() == BundleAdjustmentGauge::UNSPECIFIED &&
+        ba_config.NumImages() >= 2) {
+      ba_config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
+    }
+    bundle_adjuster =
+        CreateDefaultBundleAdjuster(ba_options, ba_config, *reconstruction_);
   }
-  // Fixing the gauge with two cameras leads to a more stable optimization
-  // with fewer steps as compared to fixing three points.
-  // TODO(jsch): Investigate whether it is safe to not fix the gauge at all,
-  // as initial experiments show that it is even faster.
-  ba_config.FixGauge(BundleAdjustmentGauge::TWO_CAMS_FROM_WORLD);
 
-  // Run bundle adjustment.
-  std::unique_ptr<BundleAdjuster> bundle_adjuster =
-      CreateDefaultBundleAdjuster(ba_options, ba_config, *reconstruction_);
-  bundle_adjuster->Solve();
+  summary_ = bundle_adjuster->Solve();
+
   reconstruction_->UpdatePoint3DErrors();
 
   run_timer.PrintMinutes();

--- a/src/colmap/controllers/bundle_adjustment.h
+++ b/src/colmap/controllers/bundle_adjustment.h
@@ -29,7 +29,8 @@
 
 #pragma once
 
-#include "colmap/controllers/option_manager.h"
+#include "colmap/estimators/bundle_adjustment.h"
+#include "colmap/geometry/pose_prior.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/util/base_controller.h"
 
@@ -38,14 +39,36 @@ namespace colmap {
 // Class that controls the global bundle adjustment procedure.
 class BundleAdjustmentController : public BaseController {
  public:
-  BundleAdjustmentController(const OptionManager& options,
-                             std::shared_ptr<Reconstruction> reconstruction);
+  BundleAdjustmentController(
+      const BundleAdjustmentOptions& ba_options,
+      const BundleAdjustmentConfig& ba_config,
+      std::shared_ptr<class Reconstruction> reconstruction);
 
-  void Run();
+  BundleAdjustmentController(
+      const BundleAdjustmentOptions& ba_options,
+      const BundleAdjustmentConfig& ba_config,
+      const PosePriorBundleAdjustmentOptions& prior_options,
+      std::vector<PosePrior> pose_priors,
+      std::shared_ptr<class Reconstruction> reconstruction);
+
+  void Run() override;
+
+  const BundleAdjustmentOptions& Options() const { return ba_options_; }
+  const BundleAdjustmentConfig& Config() const { return ba_config_; }
+  const std::shared_ptr<class Reconstruction>& Reconstruction() const {
+    return reconstruction_;
+  }
+  const std::shared_ptr<BundleAdjustmentSummary>& Summary() const {
+    return summary_;
+  }
 
  private:
-  const OptionManager& options_;
-  std::shared_ptr<Reconstruction> reconstruction_;
+  BundleAdjustmentOptions ba_options_;
+  BundleAdjustmentConfig ba_config_;
+  std::optional<PosePriorBundleAdjustmentOptions> prior_options_;
+  std::optional<std::vector<PosePrior>> pose_priors_;
+  std::shared_ptr<class Reconstruction> reconstruction_;
+  std::shared_ptr<BundleAdjustmentSummary> summary_;
 };
 
 }  // namespace colmap

--- a/src/colmap/controllers/bundle_adjustment_test.cc
+++ b/src/colmap/controllers/bundle_adjustment_test.cc
@@ -29,7 +29,8 @@
 
 #include "colmap/controllers/bundle_adjustment.h"
 
-#include "colmap/controllers/option_manager.h"
+#include "colmap/scene/database.h"
+#include "colmap/scene/database_sqlite.h"
 #include "colmap/scene/reconstruction_matchers.h"
 #include "colmap/scene/synthetic.h"
 
@@ -38,11 +39,20 @@
 namespace colmap {
 namespace {
 
+BundleAdjustmentConfig StandardConfig(const Reconstruction& reconstruction) {
+  BundleAdjustmentConfig ba_config;
+  for (const image_t image_id : reconstruction.RegImageIds()) {
+    ba_config.AddImage(image_id);
+  }
+  return ba_config;
+}
+
 TEST(BundleAdjustmentController, EmptyReconstruction) {
   auto reconstruction = std::make_shared<Reconstruction>();
 
-  OptionManager options;
-  BundleAdjustmentController controller(options, reconstruction);
+  BundleAdjustmentOptions ba_options;
+  BundleAdjustmentController controller(
+      ba_options, BundleAdjustmentConfig(), reconstruction);
   EXPECT_NO_THROW(controller.Run());
 
   EXPECT_EQ(reconstruction->NumRegImages(), 0);
@@ -59,8 +69,9 @@ TEST(BundleAdjustmentController, StopsBeforeOptimization) {
   SynthesizeDataset(synthetic_options, &gt_reconstruction);
 
   auto reconstruction = std::make_shared<Reconstruction>(gt_reconstruction);
-  OptionManager options;
-  BundleAdjustmentController controller(options, reconstruction);
+  BundleAdjustmentOptions ba_options;
+  BundleAdjustmentController controller(
+      ba_options, StandardConfig(*reconstruction), reconstruction);
   bool stop_checked = false;
   controller.SetCheckIfStoppedFunc([&stop_checked]() {
     stop_checked = true;
@@ -90,14 +101,90 @@ TEST(BundleAdjustmentController, Reconstruction) {
   noise_options.rig_from_world_translation_stddev = 0.1;
   SynthesizeNoise(noise_options, reconstruction.get());
 
-  OptionManager options;
-  BundleAdjustmentController controller(options, reconstruction);
+  BundleAdjustmentOptions ba_options;
+  BundleAdjustmentController controller(
+      ba_options, StandardConfig(*reconstruction), reconstruction);
   controller.Run();
 
+  EXPECT_TRUE(controller.Summary()->IsSolutionUsable());
   EXPECT_THAT(gt_reconstruction,
               ReconstructionNear(*reconstruction,
                                  /*max_rotation_error_deg=*/0.1,
                                  /*max_proj_center_error=*/0.1,
+                                 /*max_scale_error=*/std::nullopt,
+                                 /*num_obs_tolerance=*/0.0));
+}
+
+TEST(BundleAdjustmentController, PosePriorReconstruction) {
+  auto database = Database::Open(kInMemorySqliteDatabasePath);
+
+  Reconstruction gt_reconstruction;
+  SyntheticDatasetOptions synthetic_options;
+  synthetic_options.num_rigs = 1;
+  synthetic_options.num_cameras_per_rig = 1;
+  synthetic_options.num_frames_per_rig = 5;
+  synthetic_options.num_points3D = 100;
+  synthetic_options.prior_position = true;
+  SynthesizeDataset(synthetic_options, &gt_reconstruction, database.get());
+
+  auto reconstruction = std::make_shared<Reconstruction>(gt_reconstruction);
+
+  SyntheticNoiseOptions noise_options;
+  noise_options.point2D_stddev = 0.1;
+  noise_options.point3D_stddev = 0.1;
+  noise_options.rig_from_world_rotation_stddev = 0.1;
+  noise_options.rig_from_world_translation_stddev = 0.1;
+  noise_options.prior_position_stddev = 0.05;
+  SynthesizeNoise(noise_options, reconstruction.get());
+
+  const std::vector<PosePrior> pose_priors = database->ReadAllPosePriors();
+
+  BundleAdjustmentOptions ba_options;
+  PosePriorBundleAdjustmentOptions prior_options;
+  prior_options.alignment_ransac_options.random_seed = 0;
+  BundleAdjustmentController controller(ba_options,
+                                        StandardConfig(*reconstruction),
+                                        prior_options,
+                                        pose_priors,
+                                        reconstruction);
+  controller.Run();
+
+  ASSERT_NE(controller.Summary(), nullptr);
+  EXPECT_TRUE(controller.Summary()->IsSolutionUsable());
+  EXPECT_THAT(gt_reconstruction,
+              ReconstructionNear(*reconstruction,
+                                 /*max_rotation_error_deg=*/0.1,
+                                 /*max_proj_center_error=*/0.1,
+                                 /*max_scale_error=*/std::nullopt,
+                                 /*num_obs_tolerance=*/0.02));
+}
+
+TEST(BundleAdjustmentController, PriorWithoutPriorsFallsBack) {
+  Reconstruction gt_reconstruction;
+  SyntheticDatasetOptions synthetic_options;
+  synthetic_options.num_rigs = 1;
+  synthetic_options.num_cameras_per_rig = 1;
+  synthetic_options.num_frames_per_rig = 3;
+  synthetic_options.num_points3D = 50;
+  SynthesizeDataset(synthetic_options, &gt_reconstruction);
+
+  auto reconstruction = std::make_shared<Reconstruction>(gt_reconstruction);
+
+  BundleAdjustmentOptions ba_options;
+  PosePriorBundleAdjustmentOptions prior_options;
+  BundleAdjustmentController controller(ba_options,
+                                        StandardConfig(*reconstruction),
+                                        prior_options,
+                                        /*pose_priors=*/{},
+                                        reconstruction);
+  EXPECT_NO_THROW(controller.Run());
+
+  ASSERT_NE(controller.Summary(), nullptr);
+  EXPECT_TRUE(controller.Summary()->IsSolutionUsable());
+  EXPECT_THAT(gt_reconstruction,
+              ReconstructionNear(*reconstruction,
+                                 /*max_rotation_error_deg=*/1e-3,
+                                 /*max_proj_center_error=*/1e-3,
                                  /*max_scale_error=*/std::nullopt,
                                  /*num_obs_tolerance=*/0.0));
 }

--- a/src/colmap/exe/sfm.cc
+++ b/src/colmap/exe/sfm.cc
@@ -36,10 +36,12 @@
 #include "colmap/controllers/option_manager.h"
 #include "colmap/controllers/rotation_averaging.h"
 #include "colmap/estimators/bundle_adjustment.h"
+#include "colmap/estimators/bundle_adjustment_ceres.h"
 #include "colmap/estimators/solvers/similarity_transform.h"
 #include "colmap/estimators/view_graph_calibration.h"
 #include "colmap/exe/gui.h"
 #include "colmap/scene/reconstruction.h"
+#include "colmap/scene/reconstruction_pruning.h"
 #include "colmap/sfm/observation_manager.h"
 #include "colmap/util/cancellation.h"
 #include "colmap/util/file.h"
@@ -185,14 +187,58 @@ int RunAutomaticReconstructor(int argc, char** argv) {
   return EXIT_SUCCESS;
 }
 
+std::shared_ptr<BundleAdjustmentSummary> RunBundleAdjustmentImpl(
+    const BundleAdjustmentOptions& ba_options,
+    const BundleAdjustmentConfig& ba_config,
+    const std::shared_ptr<Reconstruction>& reconstruction,
+    const PosePriorBundleAdjustmentOptions* prior_options,
+    const std::vector<PosePrior>* pose_priors,
+    std::function<bool()> check_if_stopped) {
+  THROW_CHECK_NOTNULL(reconstruction);
+
+  std::unique_ptr<BundleAdjustmentController> ba_controller;
+  if (prior_options != nullptr && pose_priors != nullptr &&
+      !pose_priors->empty()) {
+    ba_controller = std::make_unique<BundleAdjustmentController>(
+        ba_options, ba_config, *prior_options, *pose_priors, reconstruction);
+  } else {
+    ba_controller = std::make_unique<BundleAdjustmentController>(
+        ba_options, ba_config, reconstruction);
+  }
+  ba_controller->SetCheckIfStoppedFunc(std::move(check_if_stopped));
+  ba_controller->Run();
+  return ba_controller->Summary();
+}
+
 int RunBundleAdjuster(int argc, char** argv) {
   std::filesystem::path input_path;
   std::filesystem::path output_path;
+  std::filesystem::path database_path;
+
+  BundleAdjustmentOptions ba_options;
+  PosePriorBundleAdjustmentOptions prior_ba_options;
+  bool use_prior_position = false;
+  bool use_robust_loss_on_prior_position = false;
+  bool ba_global_ignore_redundant_points3D = false;
+  double ba_global_ignore_redundant_points3D_min_coverage_gain = 0.05;
 
   OptionManager options;
   options.AddRequiredOption("input_path", &input_path);
   options.AddRequiredOption("output_path", &output_path);
   options.AddBundleAdjustmentOptions();
+  options.AddDefaultOption("use_prior_position", &use_prior_position);
+  options.AddDefaultOption("database_path", &database_path);
+  options.AddDefaultOption("use_robust_loss_on_prior_position",
+                           &use_robust_loss_on_prior_position);
+  options.AddDefaultOption("prior_position_loss_scale",
+                           &prior_ba_options.ceres->prior_position_loss_scale);
+  options.AddDefaultOption("prior_position_fallback_stddev",
+                           &prior_ba_options.prior_position_fallback_stddev);
+  options.AddDefaultOption("ba_global_ignore_redundant_points3D",
+                           &ba_global_ignore_redundant_points3D);
+  options.AddDefaultOption(
+      "ba_global_ignore_redundant_points3D_min_coverage_gain",
+      &ba_global_ignore_redundant_points3D_min_coverage_gain);
   if (!options.Parse(argc, argv)) {
     return EXIT_FAILURE;
   }
@@ -207,11 +253,64 @@ int RunBundleAdjuster(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
+  ba_options = *options.bundle_adjustment;
+  if (use_robust_loss_on_prior_position) {
+    prior_ba_options.ceres->prior_position_loss_function_type =
+        CeresLossFunctionType::CAUCHY;
+  }
+  std::vector<PosePrior> pose_priors;
+  if (use_prior_position) {
+    auto database = Database::Open(database_path);
+    pose_priors = database->ReadAllPosePriors();
+  }
+
   auto reconstruction = std::make_shared<Reconstruction>();
   reconstruction->Read(input_path);
 
-  BundleAdjustmentController ba_controller(options, reconstruction);
-  ba_controller.Run();
+  BundleAdjustmentConfig ba_config;
+  for (const image_t image_id : reconstruction->RegImageIds()) {
+    ba_config.AddImage(image_id);
+  }
+
+  std::vector<point3D_t> redundant_point3D_ids;
+  if (ba_global_ignore_redundant_points3D) {
+    redundant_point3D_ids = FindRedundantPoints3D(
+        ba_global_ignore_redundant_points3D_min_coverage_gain, *reconstruction);
+    VLOG(1) << "=> Ignoring " << redundant_point3D_ids.size() << " / "
+            << reconstruction->NumPoints3D() << " redundant 3D points";
+    for (const point3D_t point3D_id : redundant_point3D_ids) {
+      ba_config.IgnorePoint(point3D_id);
+    }
+  }
+
+  std::shared_ptr<BundleAdjustmentSummary> summary =
+      RunBundleAdjustmentImpl(ba_options,
+                              ba_config,
+                              reconstruction,
+                              use_prior_position ? &prior_ba_options : nullptr,
+                              use_prior_position ? &pose_priors : nullptr);
+
+  // Optimize the redundant 3D points with all other parameters fixed.
+  if (ba_global_ignore_redundant_points3D && !redundant_point3D_ids.empty() &&
+      summary != nullptr && summary->IsSolutionUsable()) {
+    BundleAdjustmentConfig redundant_config;
+    for (const point3D_t point3D_id : redundant_point3D_ids) {
+      redundant_config.AddVariablePoint(point3D_id);
+    }
+    for (const frame_t frame_id : reconstruction->RegFrameIds()) {
+      redundant_config.SetConstantRigFromWorldPose(frame_id);
+    }
+    for (const auto& [camera_id, _] : reconstruction->Cameras()) {
+      redundant_config.SetConstantCamIntrinsics(camera_id);
+    }
+    for (const auto& [_, rig] : reconstruction->Rigs()) {
+      for (const auto& [sensor_id, _] : rig.NonRefSensors()) {
+        redundant_config.SetConstantSensorFromRigPose(sensor_id);
+      }
+    }
+
+    RunBundleAdjustmentImpl(ba_options, redundant_config, reconstruction);
+  }
 
   reconstruction->Write(output_path);
 

--- a/src/colmap/exe/sfm.h
+++ b/src/colmap/exe/sfm.h
@@ -39,6 +39,14 @@
 
 namespace colmap {
 
+std::shared_ptr<BundleAdjustmentSummary> RunBundleAdjustmentImpl(
+    const BundleAdjustmentOptions& ba_options,
+    const BundleAdjustmentConfig& ba_config,
+    const std::shared_ptr<Reconstruction>& reconstruction,
+    const PosePriorBundleAdjustmentOptions* prior_options = nullptr,
+    const std::vector<PosePrior>* pose_priors = nullptr,
+    std::function<bool()> check_if_stopped = {});
+
 void RunPointTriangulatorImpl(
     const std::shared_ptr<Reconstruction>& reconstruction,
     const std::filesystem::path& database_path,

--- a/src/colmap/ui/bundle_adjustment_widget.cc
+++ b/src/colmap/ui/bundle_adjustment_widget.cc
@@ -149,8 +149,14 @@ void BundleAdjustmentWidget::Run() {
 
   WriteOptions();
 
+  BundleAdjustmentConfig ba_config;
+  for (const image_t image_id : reconstruction_->RegImageIds()) {
+    ba_config.AddImage(image_id);
+  }
+
   auto thread = std::make_unique<ControllerThread<BundleAdjustmentController>>(
-      std::make_shared<BundleAdjustmentController>(*options_, reconstruction_));
+      std::make_shared<BundleAdjustmentController>(
+          *options_->bundle_adjustment, ba_config, reconstruction_));
   thread->AddCallback(Thread::FINISHED_CALLBACK,
                       [this]() { render_action_->trigger(); });
 

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -160,15 +160,27 @@ std::map<size_t, std::shared_ptr<Reconstruction>> HierarchicalMapping(
 void BundleAdjustment(
     const std::shared_ptr<Reconstruction>& reconstruction,
     const BundleAdjustmentOptions& options,
+    const std::shared_ptr<BundleAdjustmentConfig>& config,
+    const std::vector<PosePrior>& pose_priors,
+    bool use_prior_position,
+    const PosePriorBundleAdjustmentOptions& prior_options,
     const std::shared_ptr<CancellationToken>& cancellation_token) {
   py::gil_scoped_release release;
-  OptionManager option_manager;
-  option_manager.bundle_adjustment =
-      std::make_shared<BundleAdjustmentOptions>(options);
+  BundleAdjustmentConfig custom_config;
+  if (config != nullptr) {
+    custom_config = *config;
+  } else {
+    for (const image_t image_id : reconstruction->RegImageIds()) {
+      custom_config.AddImage(image_id);
+    }
+  }
   PyInterruptChecker interrupt_checker(cancellation_token);
-  BundleAdjustmentController controller(option_manager, reconstruction);
-  controller.SetCheckIfStoppedFunc(interrupt_checker.Callback());
-  controller.Run();
+  RunBundleAdjustmentImpl(options,
+                          custom_config,
+                          reconstruction,
+                          use_prior_position ? &prior_options : nullptr,
+                          use_prior_position ? &pose_priors : nullptr,
+                          interrupt_checker.Callback());
   interrupt_checker.CheckAndThrow();
 }
 
@@ -274,6 +286,12 @@ void BindSfM(py::module& m) {
         "reconstruction"_a,
         py::arg_v(
             "options", BundleAdjustmentOptions(), "BundleAdjustmentOptions()"),
+        py::arg_v("config", std::shared_ptr<BundleAdjustmentConfig>(), "None"),
+        py::arg_v("pose_priors", std::vector<PosePrior>(), "[]"),
+        "use_prior_position"_a = false,
+        py::arg_v("prior_options",
+                  PosePriorBundleAdjustmentOptions(),
+                  "PosePriorBundleAdjustmentOptions()"),
         "cancellation_token"_a = py::none(),
         "Jointly refine 3D points and camera poses");
 }


### PR DESCRIPTION
## Summary

- Refactor `BundleAdjustmentController` to take `(BundleAdjustmentOptions, BundleAdjustmentConfig, ...)` instead of `OptionManager`; callers now express the BA problem (images, constants, gauge, point selection) directly.
- Add a pose-prior-based overload `(..., PosePriorBundleAdjustmentOptions, pose_priors, ...)`.
- CLI `bundle_adjuster`: prior flags and redundant-point two-stage refinement.
- pycolmap `bundle_adjustment`: backward-compatible extension (`ba_config`, `pose_priors`, `use_prior_position`, `prior_options`).
- GUI widget builds the standard config locally.
- Add shared `RunBundleAdjustmentImpl()` used by CLI and pycolmap.

## Testing

- Extended `controllers/bundle_adjustment_test.cc` (fallback, pose-prior reconstruction).