### PR TITLE
Compute pitched row offsets in size_t in the rotate/transpose/flip kernels (fixes #3207)

### DIFF
--- a/src/colmap/mvs/cuda_flip.h
+++ b/src/colmap/mvs/cuda_flip.h
@@ -72,8 +72,8 @@ __global__ void CudaFlipHorizontalKernel(T* output_data,
   for (int i = 0; i < TILE_DIM_FLIP; i += BLOCK_ROWS_FLIP) {
     const int x = min(x_index, width - 1);
     const int y = min(y_index, height - i - 1);
-    tile[tile_y + i][tile_x] =
-        *((T*)((char*)input_data + y * input_pitch + i * input_pitch) + x);
+    tile[tile_y + i][tile_x] = *(
+        (T*)((char*)input_data + static_cast<size_t>(y + i) * input_pitch) + x);
   }
 
   __syncthreads();
@@ -82,7 +82,8 @@ __global__ void CudaFlipHorizontalKernel(T* output_data,
   if (x_index < width) {
     for (int i = 0; i < TILE_DIM_FLIP; i += BLOCK_ROWS_FLIP) {
       if (y_index + i < height) {
-        *((T*)((char*)output_data + y_index * output_pitch + i * output_pitch) +
+        *((T*)((char*)output_data +
+               static_cast<size_t>(y_index + i) * output_pitch) +
           x_index) = tile[threadIdx.y + i][threadIdx.x];
       }
     }

--- a/src/colmap/mvs/cuda_rotate.h
+++ b/src/colmap/mvs/cuda_rotate.h
@@ -70,11 +70,6 @@ __global__ void CudaRotateKernel(T* output_data,
   int output_x = input_y;
   int output_y = width - 1 - input_x;
 
-  // Byte offsets must be computed in size_t: for wide element types
-  // (curandState is 48 bytes) a row offset of `y * pitch` exceeds
-  // INT_MAX above ~44.7 MP, wrapping negative and touching memory before
-  // the allocation (colmap/colmap#3207: illegal memory access on
-  // 8000x6000 images).
   *((T*)((char*)output_data + static_cast<size_t>(output_y) * output_pitch) +
     output_x) =
       *((T*)((char*)input_data + static_cast<size_t>(input_y) * input_pitch) +

--- a/src/colmap/mvs/cuda_rotate.h
+++ b/src/colmap/mvs/cuda_rotate.h
@@ -70,8 +70,15 @@ __global__ void CudaRotateKernel(T* output_data,
   int output_x = input_y;
   int output_y = width - 1 - input_x;
 
-  *((T*)((char*)output_data + output_y * output_pitch) + output_x) =
-      *((T*)((char*)input_data + input_y * input_pitch) + input_x);
+  // Byte offsets must be computed in size_t: for wide element types
+  // (curandState is 48 bytes) a row offset of `y * pitch` exceeds
+  // INT_MAX above ~44.7 MP, wrapping negative and touching memory before
+  // the allocation (colmap/colmap#3207: illegal memory access on
+  // 8000x6000 images).
+  *((T*)((char*)output_data + static_cast<size_t>(output_y) * output_pitch) +
+    output_x) =
+      *((T*)((char*)input_data + static_cast<size_t>(input_y) * input_pitch) +
+        input_x);
 }
 
 }  // namespace internal

--- a/src/colmap/mvs/cuda_transpose.h
+++ b/src/colmap/mvs/cuda_transpose.h
@@ -74,8 +74,8 @@ __global__ void CudaTransposeKernel(T* output_data,
   for (int i = 0; i < TILE_DIM_TRANSPOSE; i += BLOCK_ROWS_TRANSPOSE) {
     const int x = min(x_index, width - 1);
     const int y = min(y_index, height - i - 1);
-    tile[tile_y + i][tile_x] =
-        *((T*)((char*)input_data + y * input_pitch + i * input_pitch) + x);
+    tile[tile_y + i][tile_x] = *(
+        (T*)((char*)input_data + static_cast<size_t>(y + i) * input_pitch) + x);
   }
 
   __syncthreads();
@@ -85,7 +85,8 @@ __global__ void CudaTransposeKernel(T* output_data,
     y_index = blockIdx.x * TILE_DIM_TRANSPOSE + threadIdx.y;
     for (int i = 0; i < TILE_DIM_TRANSPOSE; i += BLOCK_ROWS_TRANSPOSE) {
       if (y_index + i < width) {
-        *((T*)((char*)output_data + y_index * output_pitch + i * output_pitch) +
+        *((T*)((char*)output_data +
+               static_cast<size_t>(y_index + i) * output_pitch) +
           x_index) = tile[threadIdx.x][threadIdx.y + i];
       }
     }

--- a/src/colmap/mvs/gpu_mat_test.cu
+++ b/src/colmap/mvs/gpu_mat_test.cu
@@ -35,33 +35,10 @@
 #include "colmap/mvs/gpu_mat.h"
 #include "colmap/mvs/gpu_mat_prng.h"
 
-#include <limits>
-
 #include <gtest/gtest.h>
 
 namespace colmap {
 namespace mvs {
-
-// Regression for colmap/colmap#3207: rotating a matrix whose row byte
-// offsets exceed INT_MAX (48-byte curandState at >= ~44.7 MP) computed
-// the offset in 32-bit arithmetic and wrote before the allocation. The
-// two 2.3 GB buffers need a GPU with >= 6 GB free; skipped otherwise.
-TEST(GpuMat, RotateLargeRowOffsets) {
-  size_t free_bytes = 0, total_bytes = 0;
-  ASSERT_EQ(cudaMemGetInfo(&free_bytes, &total_bytes), cudaSuccess);
-  const size_t width = 8000, height = 6000;
-  const size_t need = 2 * width * height * sizeof(curandState);
-  if (free_bytes < need + (512 << 20)) {
-    GTEST_SKIP() << "needs " << need / (1 << 20) << " MiB of free GPU memory";
-  }
-  ASSERT_GT(width * height * sizeof(curandState),
-            static_cast<size_t>(std::numeric_limits<int>::max()));
-  GpuMatPRNG prng_array(width, height);
-  GpuMatPRNG rotated(height, width);
-  prng_array.Rotate(&rotated);
-  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
-}
 
 TEST(GpuMat, FillWithVector) {
   GpuMat<float> array(100, 100, 2);

--- a/src/colmap/mvs/gpu_mat_test.cu
+++ b/src/colmap/mvs/gpu_mat_test.cu
@@ -35,10 +35,33 @@
 #include "colmap/mvs/gpu_mat.h"
 #include "colmap/mvs/gpu_mat_prng.h"
 
+#include <limits>
+
 #include <gtest/gtest.h>
 
 namespace colmap {
 namespace mvs {
+
+// Regression for colmap/colmap#3207: rotating a matrix whose row byte
+// offsets exceed INT_MAX (48-byte curandState at >= ~44.7 MP) computed
+// the offset in 32-bit arithmetic and wrote before the allocation. The
+// two 2.3 GB buffers need a GPU with >= 6 GB free; skipped otherwise.
+TEST(GpuMat, RotateLargeRowOffsets) {
+  size_t free_bytes = 0, total_bytes = 0;
+  ASSERT_EQ(cudaMemGetInfo(&free_bytes, &total_bytes), cudaSuccess);
+  const size_t width = 8000, height = 6000;
+  const size_t need = 2 * width * height * sizeof(curandState);
+  if (free_bytes < need + (512 << 20)) {
+    GTEST_SKIP() << "needs " << need / (1 << 20) << " MiB of free GPU memory";
+  }
+  ASSERT_GT(width * height * sizeof(curandState),
+            static_cast<size_t>(std::numeric_limits<int>::max()));
+  GpuMatPRNG prng_array(width, height);
+  GpuMatPRNG rotated(height, width);
+  prng_array.Rotate(&rotated);
+  EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+}
 
 TEST(GpuMat, FillWithVector) {
   GpuMat<float> array(100, 100, 2);


### PR DESCRIPTION
Fixes #3207 (CUDA illegal memory access in `patch_match_stereo` with large images).

### Cause

`CudaRotateKernel`, `CudaTransposeKernel` and `CudaFlipHorizontalKernel` take the pitch and the row index as `int` and compute the byte offset as `row * pitch` in 32-bit arithmetic. For wide element types that product exceeds `INT_MAX` on large images. The patch-match random-state map holds 48-byte `curandState` elements, so above roughly 44.7 MP the offsets of the last few hundred rows wrap negative and the kernels touch memory before the allocation. The slice base pointers in `GpuMat::Rotate` / `Transpose` / `FlipHorizontal` are already computed in `size_t`; only the per-row products inside the kernels were narrow.

The arithmetic matches the reports exactly:

| frame | rows whose offset overflows (input / rotated) | observed |
|---|---|---|
| 7700×5775 (the issue's `max_image_size 7700` workaround) | 0 / 0 | runs |
| 8192×5464 | 2 / 15 | appears to run — the wrapped writes land inside a neighbouring allocation (silent corruption, not a fault) |
| 8000×6000 (the issue) | 407 / 550 | faults |
| 7980×5981 (ours) | 381 / 503 | faults on an L4 and on an L40S (48 GB) alike — not a memory-capacity problem |

### Change

Compute the byte offsets in `size_t` in the three kernels. No behavioural change below the overflow line.

### Test

`GpuMat.RotateLargeRowOffsets` rotates an 8000×6000 `GpuMatPRNG` (two 2.3 GB buffers) and checks the device reports no error; it skips itself when the GPU has less than ~5 GB free, so CI without a large GPU is unaffected.

Verified by static analysis of every known data point; a full `patch_match_stereo` run on the 7980×5981 set with this patch is in progress on an L40S and I will report the result here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
