### PR TITLE
Fix Sim3dNear matcher ignoring the scale tolerance

### DIFF
--- a/src/colmap/geometry/sim3_matchers.h
+++ b/src/colmap/geometry/sim3_matchers.h
@@ -72,7 +72,7 @@ template <typename T>
 class Sim3dNearMatcher : public testing::MatcherInterface<T> {
  public:
   Sim3dNearMatcher(T rhs, double stol, double rtol, double ttol)
-      : rhs_(std::forward<T>(rhs)), stol_(rtol), rtol_(rtol), ttol_(ttol) {}
+      : rhs_(std::forward<T>(rhs)), stol_(stol), rtol_(rtol), ttol_(ttol) {}
 
   void DescribeTo(std::ostream* os) const override { *os << rhs_; }
 

--- a/src/colmap/geometry/sim3_matchers_test.cc
+++ b/src/colmap/geometry/sim3_matchers_test.cc
@@ -90,6 +90,18 @@ TEST(Sim3d, Near) {
   mock.TestMethod(y);
 }
 
+TEST(Sim3d, NearUsesIndependentScaleTolerance) {
+  const Sim3d x(2, RandomEigenQuaterniond(), RandomEigenVectord<3>());
+  Sim3d y = x;
+  y.scale() += 1e-7;
+  // The scale difference is above stol but below rtol/ttol, so only the
+  // scale check must reject the match. This fails if the scale comparison
+  // wrongly uses rtol instead of stol.
+  EXPECT_THAT(
+      x, testing::Not(Sim3dNear(y, /*stol=*/1e-8, /*rtol=*/1, /*ttol=*/1)));
+  EXPECT_THAT(x, Sim3dNear(y, /*stol=*/1e-6, /*rtol=*/1e-8, /*ttol=*/1e-8));
+}
+
 TEST(Sim3d, LeftScaleNearIdentity) {
   Sim3d x(1, Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
   Sim3d y = x;


### PR DESCRIPTION
Sim3dNearMatcher initialized `stol_` from `rtol`, so the caller's scale tolerance was silently dropped and the rotation tolerance gated the scale comparison instead. All existing call sites passed `stol == rtol`, which is why nothing caught it.

- Fix the initializer to `stol_(stol)`.
- Add `Sim3d.NearUsesIndependentScaleTolerance`, which fails before the fix (verified) and passes after.

Test plan: `sim3_matchers_test` 9/9 pass; clang-format clean.