### PR TITLE
Fix PoissonRecon endianness initialization in PlyFile.inl

### DIFF
--- a/src/thirdparty/PoissonRecon/PlyFile.inl
+++ b/src/thirdparty/PoissonRecon/PlyFile.inl
@@ -104,7 +104,17 @@ typedef union
 } endian_test_type;
 
 
+// Determine machine endianness at compile time so native_binary_type is
+// consistently initialized across all translation units including this header.
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+static constexpr int native_binary_type =
+    (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) ? PLY_BINARY_LE
+                                                : PLY_BINARY_BE;
+#elif defined(_WIN32)
+static constexpr int native_binary_type = PLY_BINARY_LE;
+#else
 static int native_binary_type = -1;
+#endif
 static int types_checked = 0;
 
 static const int no_other_props = -1;
@@ -1270,6 +1280,7 @@ either PLY_BINARY_BE or PLY_BINARY_LE
 
 void get_native_binary_type( void )
 {
+#if !defined(__BYTE_ORDER__) && !defined(_WIN32)
 	endian_test_type test;
 
 	test.int_value = 0;
@@ -1277,6 +1288,7 @@ void get_native_binary_type( void )
 	if     ( test.byte_values[0]==1 ) native_binary_type = PLY_BINARY_LE;
 	else if( test.byte_values[sizeof(int)-1] == 1) native_binary_type = PLY_BINARY_BE;
 	else MK_THROW( "Couldn't determine machine endianness" );
+#endif
 }
 
 /******************************************************************************


### PR DESCRIPTION
### Problem

In `src/thirdparty/PoissonRecon/PlyFile.inl`, `native_binary_type` was declared as a `static int native_binary_type = -1;` in a header file included by multiple translation units (e.g., `PoissonRecon.cpp`, `SurfaceTrimmer.cpp`, etc.).

Because static variables in headers have internal linkage, each translation unit receives its own copy. When `native_binary_type` was initialized at runtime in one translation unit via `get_native_binary_type()`, it remained `-1` in others.

As a consequence, when reading or writing binary PLY files (where `file_type` is `PLY_BINARY_LE`), uninitialized translation units evaluated `file_type != native_binary_type` (`1 != -1`) as true, triggering `swap_bytes` on all binary floats and integer indices. This corrupted mesh data and caused segmentation faults during trimming (e.g., in `PoissonMeshing.WithTrimming`).

### Solution

Determine machine endianness at compile time using standard preprocessor macros (`__BYTE_ORDER__` on GCC/Clang, `_WIN32` on Windows/MSVC) and define `native_binary_type` as a `constexpr int`.

This guarantees:
1. `native_binary_type` is consistently and immutably initialized across all translation units.
2. No runtime initialization or concurrency issues when multiple threads/units interact with PLY operations.
3. Fallback to runtime detection if neither macro is defined.

### Verification
- Built and verified with `poisson_meshing_test` (`PoissonMeshing.Integration` and `PoissonMeshing.WithTrimming` both pass).