### PR TITLE
Honor min_inlier_ratio consistently in two-view geometry estimation

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -460,7 +460,7 @@ void OptionManager::AddTwoViewGeometryOptions() {
   AddDefaultOption("TwoViewGeometry.max_num_trials",
                    &two_view_geometry->ransac_options.max_num_trials);
   AddDefaultOption("TwoViewGeometry.min_inlier_ratio",
-                   &two_view_geometry->ransac_options.min_inlier_ratio);
+                   &two_view_geometry->min_inlier_ratio);
   AddDefaultOption("TwoViewGeometry.random_seed",
                    &two_view_geometry->ransac_options.random_seed);
 }

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -250,9 +250,10 @@ RANSACOptions RansacOptionsWithMinInlierRatio(
 // Budget the homography search for the inlier ratio it must reach to be
 // selected over the competing model, since a weaker one is discarded anyway.
 RANSACOptions HomographyRansacOptions(const TwoViewGeometryOptions& options,
-                                      const RANSACOptions& base_ransac_options,
                                       size_t competing_num_inliers,
                                       size_t num_matches) {
+  const RANSACOptions base_ransac_options =
+      RansacOptionsWithMinInlierRatio(options);
   RANSACOptions H_ransac_options = base_ransac_options;
   H_ransac_options.min_inlier_ratio = std::max(
       base_ransac_options.min_inlier_ratio,
@@ -415,10 +416,8 @@ TwoViewGeometry EstimateUncalibratedTwoViewGeometry(
   LORANSAC<HomographyMatrixEstimator,
            HomographyMatrixEstimator,
            MEstimatorSupportMeasurer>
-      H_ransac(HomographyRansacOptions(options,
-                                       options.ransac_options,
-                                       F_report.support.num_inliers,
-                                       matches.size()));
+      H_ransac(HomographyRansacOptions(
+          options, F_report.support.num_inliers, matches.size()));
   const auto H_report =
       H_ransac.Estimate(matched_img_points1, matched_img_points2);
   geometry.H = H_report.model;
@@ -587,10 +586,8 @@ TwoViewGeometry EstimateSphericalTwoViewGeometry(
       LORANSAC<HomographyMatrixRayEstimator,
                HomographyMatrixRayEstimator,
                MEstimatorSupportMeasurer>(
-          HomographyRansacOptions(options,
-                                  RansacOptionsWithMinInlierRatio(options),
-                                  E_report.support.num_inliers,
-                                  matches.size()),
+          HomographyRansacOptions(
+              options, E_report.support.num_inliers, matches.size()),
           H_estimator,
           H_estimator)
           .Estimate(matched_cam_rays1, matched_cam_rays2);
@@ -1143,8 +1140,8 @@ TwoViewGeometry EstimateCalibratedTwoViewGeometry(
       std::min(E_report.support.num_inliers, F_report.support.num_inliers);
   // Undistorted pinhole cameras keep the pixel estimator, where the two are
   // algebraically equivalent.
-  const RANSACOptions H_ransac_options = HomographyRansacOptions(
-      options, ransac_options, competing_num_inliers, matches.size());
+  const RANSACOptions H_ransac_options =
+      HomographyRansacOptions(options, competing_num_inliers, matches.size());
   const auto H_report =
       (camera1.IsUndistorted() && camera2.IsUndistorted())
           ? LORANSAC<HomographyMatrixEstimator,
@@ -1303,10 +1300,8 @@ TwoViewGeometry EstimateSharedFocalTwoViewGeometry(
   LORANSAC<HomographyMatrixEstimator,
            HomographyMatrixEstimator,
            MEstimatorSupportMeasurer>
-      H_ransac(HomographyRansacOptions(options,
-                                       RansacOptionsWithMinInlierRatio(options),
-                                       SF_report.support.num_inliers,
-                                       matches.size()));
+      H_ransac(HomographyRansacOptions(
+          options, SF_report.support.num_inliers, matches.size()));
   const auto H_report =
       H_ransac.Estimate(matched_img_points1, matched_img_points2);
   geometry.H = H_report.model;
@@ -1487,10 +1482,8 @@ TwoViewGeometry EstimateOneSidedFocalTwoViewGeometry(
   LORANSAC<HomographyMatrixEstimator,
            HomographyMatrixEstimator,
            MEstimatorSupportMeasurer>
-      H_ransac(HomographyRansacOptions(options,
-                                       RansacOptionsWithMinInlierRatio(options),
-                                       focal_report.support.num_inliers,
-                                       matches.size()));
+      H_ransac(HomographyRansacOptions(
+          options, focal_report.support.num_inliers, matches.size()));
   LORANSAC<HomographyMatrixEstimator,
            HomographyMatrixEstimator,
            MEstimatorSupportMeasurer>::Report H_report;

--- a/src/colmap/estimators/two_view_geometry.cc
+++ b/src/colmap/estimators/two_view_geometry.cc
@@ -355,6 +355,13 @@ TwoViewGeometry EstimateCalibratedHomography(
 
   geometry.inlier_matches = ExtractInlierMatches(
       matches, H_report.support.num_inliers, H_report.inlier_mask);
+
+  // Check inlier ratio threshold.
+  if (!CheckMinInlierRatioOrDegenerate(
+          H_report.support.num_inliers, matches.size(), options, &geometry)) {
+    return geometry;
+  }
+
   MaybeMarkWatermark(camera1,
                      matched_img_points1,
                      camera2,
@@ -391,10 +398,11 @@ TwoViewGeometry EstimateUncalibratedTwoViewGeometry(
 
   // Estimate epipolar model.
 
-  const auto F_report = EstimateFundamentalMatrix(options,
-                                                  options.ransac_options,
-                                                  matched_img_points1,
-                                                  matched_img_points2);
+  const auto F_report =
+      EstimateFundamentalMatrix(options,
+                                RansacOptionsWithMinInlierRatio(options),
+                                matched_img_points1,
+                                matched_img_points2);
   geometry.F = F_report.model;
 
   // Estimate planar or panoramic model. Estimated on image points rather than
@@ -442,6 +450,12 @@ TwoViewGeometry EstimateUncalibratedTwoViewGeometry(
 
   geometry.inlier_matches =
       ExtractInlierMatches(matches, num_inliers, *best_inlier_mask);
+
+  // Check inlier ratio threshold.
+  if (!CheckMinInlierRatioOrDegenerate(
+          num_inliers, matches.size(), options, &geometry)) {
+    return geometry;
+  }
 
   MaybeMarkWatermark(camera1,
                      matched_img_points1,
@@ -635,6 +649,8 @@ TwoViewGeometry EstimateSphericalTwoViewGeometry(
 
 bool TwoViewGeometryOptions::Check() const {
   CHECK_OPTION_GE(min_num_inliers, 0);
+  CHECK_OPTION_GE(min_inlier_ratio, 0);
+  CHECK_OPTION_LE(min_inlier_ratio, 1);
   CHECK_OPTION_GE(min_E_F_inlier_ratio, 0);
   CHECK_OPTION_LE(min_E_F_inlier_ratio, 1);
   CHECK_OPTION_GE(max_H_inlier_ratio, 0);
@@ -818,7 +834,7 @@ EstimateRigTwoViewGeometries(
   std::optional<Rigid3d> maybe_pano2_from_pano1;
   size_t num_inliers;
   std::vector<char> inlier_mask;
-  if (!EstimateGeneralizedRelativePose(options.ransac_options,
+  if (!EstimateGeneralizedRelativePose(RansacOptionsWithMinInlierRatio(options),
                                        points1,
                                        points2,
                                        camera_idxs1,
@@ -830,6 +846,13 @@ EstimateRigTwoViewGeometries(
                                        &num_inliers,
                                        &inlier_mask) ||
       num_inliers < static_cast<size_t>(options.min_num_inliers)) {
+    return {};
+  }
+
+  // Check inlier ratio threshold over the aggregate correspondences.
+  if (options.min_inlier_ratio > 0 &&
+      static_cast<double>(num_inliers) / corrs.size() <
+          options.min_inlier_ratio) {
     return {};
   }
 

--- a/src/colmap/estimators/two_view_geometry_test.cc
+++ b/src/colmap/estimators/two_view_geometry_test.cc
@@ -390,6 +390,17 @@ TwoViewGeometryTestData CreateTwoViewGeometryTestData(
   return data;
 }
 
+TEST(TwoViewGeometryOptions, CheckMinInlierRatioBounds) {
+  TwoViewGeometryOptions options;
+  EXPECT_TRUE(options.Check());
+  options.min_inlier_ratio = -0.1;
+  EXPECT_FALSE(options.Check());
+  options.min_inlier_ratio = 1.1;
+  EXPECT_FALSE(options.Check());
+  options.min_inlier_ratio = 1.0;
+  EXPECT_TRUE(options.Check());
+}
+
 TEST(EstimateTwoViewGeometry, Spherical) {
   SyntheticDatasetOptions synthetic_dataset_options;
   synthetic_dataset_options.num_rigs = 2;

--- a/src/colmap/ui/feature_matching_widget.cc
+++ b/src/colmap/ui/feature_matching_widget.cc
@@ -178,7 +178,7 @@ void FeatureMatchingTab::CreateGeneralOptions() {
       &options_->two_view_geometry->ransac_options.max_num_trials,
       "max_num_trials");
   options_widget_->AddOptionDouble(
-      &options_->two_view_geometry->ransac_options.min_inlier_ratio,
+      &options_->two_view_geometry->min_inlier_ratio,
       "min_inlier_ratio",
       0,
       1,


### PR DESCRIPTION
Stacked on #4695. Routes `TwoViewGeometryOptions::min_inlier_ratio` through the estimation paths that ignored it, so all two-view geometry functions in `two_view_geometry.cc` now honor the option:

- Uncalibrated path: fundamental-matrix RANSAC uses `RansacOptionsWithMinInlierRatio`, and the selected model is rejected via `CheckMinInlierRatioOrDegenerate` below the threshold
- Forced-homography path (`force_H_use`): final model rejected below the threshold
- Rig path: generalized relative pose RANSAC uses the override, and aggregate `num_inliers / corrs.size()` below the threshold rejects the pair
- `TwoViewGeometryOptions::Check()` validates `min_inlier_ratio` to [0, 1]

The spherical, calibrated, shared-focal, and one-sided-focal paths already honored the option; `EstimateMultipleTwoViewGeometries` delegates to those. `TwoViewGeometryFromKnownRelativePose` has no ratio option and is out of scope.

Behavior change note: pairs in the three paths above whose inlier ratio falls below a configured `min_inlier_ratio` (> 0) are now rejected as degenerate/empty. At the default 0.0 nothing changes.

## Test plan

- `ninja` full build clean (Release, Ninja)
- New `TwoViewGeometryOptions.CheckMinInlierRatioBounds` test
- `ctest -R estimators` — 35/35 pass; downstream (`feature_matching_test`, `pairing_test`, pipelines) — all pass (39/39 combined)
- `clang-format --dry-run --Werror` clean
- Rejection behavior in all three paths was validated with temporary tests (failed before, passed after) that were removed again per review

## Two-view geometry benchmark (ETH3D, 13 scenes)

Reused the existing benchmark databases (features, raw matches, cameras) and recomputed only the two-view geometries via `geometric_verifier` (single-threaded, fixed seed, `compute_relative_pose=1`): 9,222 exhaustive pairs each from calibrated-prior DBs (E/F/H path) and no-prior DBs (F/H path). Arms: main (`83f273e90`) vs PR tip (`1742dd5bf`) at defaults, plus PR with top-level `min_inlier_ratio` in {0, 0.1, 0.25, 0.5, 0.75, 0.9}. Scoring: pose error = max(R, t) vs ETH3D GT (uncalibrated pairs scored by upgrading F with GT K + cheiral decomposition); recall denominator = pairs sharing >= 15 GT points.

Production behavior at 0.25 (main already enforces the recheck in the calibrated path, so production-main there equals the PR arm):

| cell | arm | est. | acc@1/2/5/10 | rec@5 | verify |
|---|---|---|---|---|---|
| cal | main = PR | 5110 | 0.174 / 0.351 / 0.588 / 0.689 | 0.605 | ~253s, 27.5ms/pair |
| uncal | main | 5160 | 0.457 / 0.540 / 0.626 / 0.685 | 0.651 | 42.7s, 4.6ms/pair |
| uncal | PR | 5103 | 0.462 / 0.546 / 0.632 / 0.691 | 0.650 | 42.8s, 4.6ms/pair |

Calibrated is bit-identical on all 13 scenes. Uncalibrated newly rejects 57 pairs (courtyard 7, facade 50; other 11 scenes identical); 53 of the 57 were wrong and only 4 correct@5, so acc@5 +0.6pp at rec@5 -0.1pp. Runtime is unchanged (one +10% wobble on a single scene traced to machine noise via re-run: 131s -> 114s vs 113s baseline; outputs are bit-identical so the compute is identical).

Threshold sweep on the PR (pooled over scenes), showing the accuracy/recall dial the newly enforced rejections provide:

| min_inlier_ratio | cell | est. | acc@5 | rec@5 | verify |
|---|---|---|---|---|---|
| 0 (= main) | cal / uncal | 5161 / 5160 | 0.583 / 0.626 | 0.606 / 0.651 | 252s / 43s |
| 0.1 | cal / uncal | 5161 / 5160 | 0.583 / 0.626 | 0.606 / 0.651 | 261s / 47s |
| 0.25 | cal / uncal | 5110 / 5103 | 0.588 / 0.632 | 0.605 / 0.650 | 253s / 43s |
| 0.5 | cal / uncal | 4337 / 4335 | 0.663 / 0.718 | 0.580 / 0.627 | 75s / 21s |
| 0.75 | cal / uncal | 2786 / 2774 | 0.747 / 0.835 | 0.420 / 0.467 | 31s / 9s |
| 0.9 | cal / uncal | 1012 / 1004 | 0.783 / 0.906 | 0.160 / 0.183 | 17s / 6s |

Validity notes:

- Control arm (PR at defaults) is bit-identical to main on all 26 cell-scenes.
- At 0.1, metrics are identical to 0 (no estimated pair has inlier ratio below 0.1); the only deltas are H-matrix float bits on some pairs from the larger H-RANSAC trial budget, with unchanged inlier sets and poses.
- Post-filtering main-only outputs at each threshold reproduces the PR arms pair-for-pair with identical errors, so the trade-off is driven by the rejection itself, not the RANSAC trial-budget change; stricter ratios additionally cut verification time up to 16x with no accuracy loss on survivors.
- `force_H_use` and rig paths are not exercised here (off / no rigs in ETH3D dslr).
