### PR TITLE
Deduplicate UI painters with shared PainterBase

### DIFF
--- a/src/colmap/ui/CMakeLists.txt
+++ b/src/colmap/ui/CMakeLists.txt
@@ -61,6 +61,7 @@ COLMAP_ADD_LIBRARY(
         model_viewer_widget.h model_viewer_widget.cc
         movie_grabber_widget.h movie_grabber_widget.cc
         options_widget.h options_widget.cc
+        painter_base.h painter_base.cc
         point_painter.h point_painter.cc
         point_viewer_widget.h point_viewer_widget.cc
         project_widget.h project_widget.cc

--- a/src/colmap/ui/line_painter.cc
+++ b/src/colmap/ui/line_painter.cc
@@ -29,109 +29,34 @@
 
 #include "colmap/ui/line_painter.h"
 
-#include "colmap/util/opengl_utils.h"
-
 namespace colmap {
 
-LinePainter::LinePainter() : num_geoms_(0) {}
-
-LinePainter::~LinePainter() {
-  vao_.destroy();
-  vbo_.destroy();
-}
-
 void LinePainter::Setup() {
-  vao_.destroy();
-  vbo_.destroy();
-  if (shader_program_.isLinked()) {
-    shader_program_.release();
-    shader_program_.removeAllShaders();
-  }
-
-  shader_program_.addShaderFromSourceFile(QOpenGLShader::Vertex,
-                                          ":/shaders/lines.v.glsl");
-  shader_program_.addShaderFromSourceFile(QOpenGLShader::Geometry,
-                                          ":/shaders/lines.g.glsl");
-  shader_program_.addShaderFromSourceFile(QOpenGLShader::Fragment,
-                                          ":/shaders/lines.f.glsl");
-  shader_program_.link();
-  shader_program_.bind();
-
-  vao_.create();
-  vbo_.create();
-
-#if DEBUG
-  glDebugLog();
-#endif
+  SetupShaders({{QOpenGLShader::Vertex, ":/shaders/lines.v.glsl"},
+                {QOpenGLShader::Geometry, ":/shaders/lines.g.glsl"},
+                {QOpenGLShader::Fragment, ":/shaders/lines.f.glsl"}});
 }
 
 void LinePainter::Upload(const std::vector<LinePainter::Data>& data) {
-  num_geoms_ = data.size();
-  if (num_geoms_ == 0) {
-    return;
-  }
-
-  vao_.bind();
-  vbo_.bind();
-
-  // Upload data array to GPU
-  vbo_.setUsagePattern(QOpenGLBuffer::DynamicDraw);
-  vbo_.allocate(data.data(),
-                static_cast<int>(data.size() * sizeof(LinePainter::Data)));
-
-  // in_position
-  shader_program_.enableAttributeArray("a_pos");
-  shader_program_.setAttributeBuffer(
-      "a_pos", GL_FLOAT, 0, 3, sizeof(PointPainter::Data));
-
-  // in_color: use glVertexAttribPointer directly because Qt's
-  // setAttributeBuffer does not support the normalized parameter,
-  // which is needed to map uint8 [0,255] to float [0.0,1.0] in the shader.
-  shader_program_.enableAttributeArray("a_color");
-  QOpenGLFunctions* gl_funcs = QOpenGLContext::currentContext()->functions();
-  gl_funcs->glVertexAttribPointer(
-      shader_program_.attributeLocation("a_color"),
-      4,
-      GL_UNSIGNED_BYTE,
-      GL_TRUE,
-      sizeof(PointPainter::Data),
-      reinterpret_cast<const void*>(  // NOLINT(performance-no-int-to-ptr)
-          3 * sizeof(GLfloat)));
-
-  // Make sure they are not changed from the outside
-  vbo_.release();
-  vao_.release();
-
-#if DEBUG
-  glDebugLog();
-#endif
+  UploadGeoms(data, "a_pos", sizeof(PointPainter::Data));
 }
 
 void LinePainter::Render(const QMatrix4x4& pmv_matrix,
                          const int width,
                          const int height,
                          const float line_width) {
-  if (num_geoms_ == 0) {
+  if (!BeginRender()) {
     return;
   }
-
-  shader_program_.bind();
-  vao_.bind();
 
   shader_program_.setUniformValue("u_pmv_matrix", pmv_matrix);
   shader_program_.setUniformValue("u_inv_viewport",
                                   QVector2D(1.0f / width, 1.0f / height));
   shader_program_.setUniformValue("u_line_width", line_width);
 
-  QOpenGLFunctions* gl_funcs = QOpenGLContext::currentContext()->functions();
-  gl_funcs->glDrawArrays(GL_LINES, 0, (GLsizei)(2 * num_geoms_));
+  GLFunctions()->glDrawArrays(GL_LINES, 0, (GLsizei)(2 * num_geoms_));
 
-  // Make sure the VAO is not changed from the outside
-  vao_.release();
-
-#if DEBUG
-  glDebugLog();
-#endif
+  EndRender();
 }
 
 }  // namespace colmap

--- a/src/colmap/ui/line_painter.h
+++ b/src/colmap/ui/line_painter.h
@@ -36,10 +36,10 @@
 
 namespace colmap {
 
-class LinePainter {
+class LinePainter : public PainterBase {
  public:
-  LinePainter();
-  ~LinePainter();
+  LinePainter() = default;
+  ~LinePainter() = default;
 
   struct Data {
     Data() {}
@@ -56,13 +56,6 @@ class LinePainter {
               int width,
               int height,
               float line_width);
-
- private:
-  QOpenGLShaderProgram shader_program_;
-  QOpenGLVertexArrayObject vao_;
-  QOpenGLBuffer vbo_;
-
-  size_t num_geoms_;
 };
 
 }  // namespace colmap

--- a/src/colmap/ui/mesh_painter.cc
+++ b/src/colmap/ui/mesh_painter.cc
@@ -29,57 +29,32 @@
 
 #include "colmap/ui/mesh_painter.h"
 
-#include "colmap/util/opengl_utils.h"
-
 #include <algorithm>
 
 namespace colmap {
 
-MeshPainter::MeshPainter() : num_vertices_(0) {}
-
 MeshPainter::~MeshPainter() {
-  vao_.destroy();
-  vbo_.destroy();
   if (texture_id_ != 0) {
-    QOpenGLFunctions* gl_funcs = QOpenGLContext::currentContext()->functions();
-    gl_funcs->glDeleteTextures(1, &texture_id_);
+    QOpenGLContext::currentContext()->functions()->glDeleteTextures(
+        1, &texture_id_);
   }
 }
 
 void MeshPainter::Setup() {
-  vao_.destroy();
-  vbo_.destroy();
   if (texture_id_ != 0) {
-    QOpenGLFunctions* gl_funcs = QOpenGLContext::currentContext()->functions();
-    gl_funcs->glDeleteTextures(1, &texture_id_);
+    QOpenGLContext::currentContext()->functions()->glDeleteTextures(
+        1, &texture_id_);
     texture_id_ = 0;
     has_texture_ = false;
   }
-  if (shader_program_.isLinked()) {
-    shader_program_.release();
-    shader_program_.removeAllShaders();
-  }
-
-  shader_program_.addShaderFromSourceFile(QOpenGLShader::Vertex,
-                                          ":/shaders/mesh.v.glsl");
-  shader_program_.addShaderFromSourceFile(QOpenGLShader::Geometry,
-                                          ":/shaders/mesh.g.glsl");
-  shader_program_.addShaderFromSourceFile(QOpenGLShader::Fragment,
-                                          ":/shaders/mesh.f.glsl");
-  shader_program_.link();
-  shader_program_.bind();
-
-  vao_.create();
-  vbo_.create();
-
-#if DEBUG
-  glDebugLog();
-#endif
+  SetupShaders({{QOpenGLShader::Vertex, ":/shaders/mesh.v.glsl"},
+                {QOpenGLShader::Geometry, ":/shaders/mesh.g.glsl"},
+                {QOpenGLShader::Fragment, ":/shaders/mesh.f.glsl"}});
 }
 
 void MeshPainter::Upload(const std::vector<MeshPainter::Data>& data) {
-  num_vertices_ = data.size();
-  if (num_vertices_ == 0) {
+  num_geoms_ = data.size();
+  if (num_geoms_ == 0) {
     return;
   }
 
@@ -124,9 +99,7 @@ void MeshPainter::Upload(const std::vector<MeshPainter::Data>& data) {
   vbo_.release();
   vao_.release();
 
-#if DEBUG
   glDebugLog();
-#endif
 }
 
 void MeshPainter::UploadTexture(std::vector<uint8_t> data,
@@ -187,12 +160,9 @@ void MeshPainter::Render(const QMatrix4x4& pmv_matrix,
                          const QMatrix4x4& model_view_matrix,
                          const bool wireframe,
                          const bool color) {
-  if (num_vertices_ == 0) {
+  if (!BeginRender()) {
     return;
   }
-
-  shader_program_.bind();
-  vao_.bind();
 
   shader_program_.setUniformValue("u_pmv_matrix", pmv_matrix);
   shader_program_.setUniformValue("u_model_view_matrix", model_view_matrix);
@@ -211,17 +181,13 @@ void MeshPainter::Render(const QMatrix4x4& pmv_matrix,
   }
 
   gl_funcs->glEnable(GL_DEPTH_TEST);
-  gl_funcs->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(num_vertices_));
+  gl_funcs->glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(num_geoms_));
 
   if (has_texture_) {
     gl_funcs->glBindTexture(GL_TEXTURE_2D, 0);
   }
 
-  vao_.release();
-
-#if DEBUG
-  glDebugLog();
-#endif
+  EndRender();
 }
 
 }  // namespace colmap

--- a/src/colmap/ui/mesh_painter.h
+++ b/src/colmap/ui/mesh_painter.h
@@ -29,15 +29,17 @@
 
 #pragma once
 
+#include "colmap/ui/painter_base.h"
+
 #include <QtCore>
 #include <QtOpenGL>
 #include <cstdint>
 
 namespace colmap {
 
-class MeshPainter {
+class MeshPainter : public PainterBase {
  public:
-  MeshPainter();
+  MeshPainter() = default;
   ~MeshPainter();
 
   struct Data {
@@ -114,11 +116,6 @@ class MeshPainter {
               bool color);
 
  private:
-  QOpenGLShaderProgram shader_program_;
-  QOpenGLVertexArrayObject vao_;
-  QOpenGLBuffer vbo_;
-
-  size_t num_vertices_;
   GLuint texture_id_ = 0;
   bool has_texture_ = false;
 };

--- a/src/colmap/ui/painter_base.cc
+++ b/src/colmap/ui/painter_base.cc
@@ -27,40 +27,59 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "colmap/ui/point_painter.h"
-
-#include <cstddef>
+#include "colmap/ui/painter_base.h"
 
 namespace colmap {
 
-// PainterBase uploads vertices as 3 floats + 4 bytes with the color at byte
-// offset 12; line and triangle painters additionally rely on Data being a
-// contiguous array of vertices.
-static_assert(sizeof(PointPainter::Data) ==
-              3 * sizeof(float) + 4 * sizeof(uint8_t));
-static_assert(offsetof(PointPainter::Data, r) == 3 * sizeof(float));
+PainterBase::PainterBase() : num_geoms_(0) {}
 
-void PointPainter::Setup() {
-  SetupShaders({{QOpenGLShader::Vertex, ":/shaders/points.v.glsl"},
-                {QOpenGLShader::Fragment, ":/shaders/points.f.glsl"}});
+PainterBase::~PainterBase() { DestroyGL(); }
+
+void PainterBase::DestroyGL() {
+  vao_.destroy();
+  vbo_.destroy();
 }
 
-void PointPainter::Upload(const std::vector<PointPainter::Data>& data) {
-  UploadGeoms(data, "a_position", sizeof(PointPainter::Data));
-}
-
-void PointPainter::Render(const QMatrix4x4& pmv_matrix,
-                          const float point_size) {
-  if (!BeginRender()) {
-    return;
+void PainterBase::SetupShaders(
+    std::initializer_list<std::pair<QOpenGLShader::ShaderType, const char*>>
+        shaders) {
+  DestroyGL();
+  if (shader_program_.isLinked()) {
+    shader_program_.release();
+    shader_program_.removeAllShaders();
   }
 
-  shader_program_.setUniformValue("u_pmv_matrix", pmv_matrix);
-  shader_program_.setUniformValue("u_point_size", point_size);
+  for (const auto& [type, path] : shaders) {
+    shader_program_.addShaderFromSourceFile(type, path);
+  }
+  shader_program_.link();
+  shader_program_.bind();
 
-  GLFunctions()->glDrawArrays(GL_POINTS, 0, (GLsizei)num_geoms_);
+  vao_.create();
+  vbo_.create();
 
-  EndRender();
+  glDebugLog();
+}
+
+bool PainterBase::BeginRender() {
+  if (num_geoms_ == 0) {
+    return false;
+  }
+
+  shader_program_.bind();
+  vao_.bind();
+  return true;
+}
+
+void PainterBase::EndRender() {
+  // Make sure the VAO is not changed from the outside
+  vao_.release();
+
+  glDebugLog();
+}
+
+QOpenGLFunctions* PainterBase::GLFunctions() {
+  return QOpenGLContext::currentContext()->functions();
 }
 
 }  // namespace colmap

--- a/src/colmap/ui/painter_base.h
+++ b/src/colmap/ui/painter_base.h
@@ -1,0 +1,119 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "colmap/util/opengl_utils.h"
+
+#include <QtCore>
+#include <QtOpenGL>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace colmap {
+
+// Shared OpenGL setup/upload/render logic for the point, line, and triangle
+// painters. All of them store vertices as a 3-float position followed by a
+// 4-byte RGBA color, with multi-vertex primitives (lines, triangles) stored as
+// contiguous arrays of such vertices. Subclasses only provide the shader
+// files, the position attribute name, and their Render uniforms.
+class PainterBase {
+ public:
+  PainterBase();
+  ~PainterBase();
+
+  PainterBase(const PainterBase&) = delete;
+  PainterBase& operator=(const PainterBase&) = delete;
+
+ protected:
+  void DestroyGL();
+  void SetupShaders(
+      std::initializer_list<std::pair<QOpenGLShader::ShaderType, const char*>>
+          shaders);
+
+  // Upload per-primitive data; vertex_stride is the size of a single vertex
+  // (e.g. sizeof(PointPainter::Data)) and may be smaller than
+  // sizeof(GeomData) for multi-vertex primitives.
+  template <typename GeomData>
+  void UploadGeoms(const std::vector<GeomData>& data,
+                   const char* position_attr,
+                   size_t vertex_stride) {
+    num_geoms_ = data.size();
+    if (num_geoms_ == 0) {
+      return;
+    }
+
+    vao_.bind();
+    vbo_.bind();
+
+    // Upload data array to GPU
+    vbo_.setUsagePattern(QOpenGLBuffer::DynamicDraw);
+    vbo_.allocate(data.data(),
+                  static_cast<int>(data.size() * sizeof(GeomData)));
+
+    // in_position
+    shader_program_.enableAttributeArray(position_attr);
+    shader_program_.setAttributeBuffer(
+        position_attr, GL_FLOAT, 0, 3, vertex_stride);
+
+    // in_color: use glVertexAttribPointer directly because Qt's
+    // setAttributeBuffer does not support the normalized parameter,
+    // which is needed to map uint8 [0,255] to float [0.0,1.0] in the shader.
+    shader_program_.enableAttributeArray("a_color");
+    QOpenGLFunctions* gl_funcs = QOpenGLContext::currentContext()->functions();
+    gl_funcs->glVertexAttribPointer(
+        shader_program_.attributeLocation("a_color"),
+        4,
+        GL_UNSIGNED_BYTE,
+        GL_TRUE,
+        vertex_stride,
+        reinterpret_cast<const void*>(  // NOLINT(performance-no-int-to-ptr)
+            3 * sizeof(GLfloat)));
+
+    // Make sure they are not changed from the outside
+    vbo_.release();
+    vao_.release();
+
+    glDebugLog();
+  }
+
+  // Bind shader program and VAO for rendering; returns false when empty.
+  bool BeginRender();
+  void EndRender();
+  QOpenGLFunctions* GLFunctions();
+
+  QOpenGLShaderProgram shader_program_;
+  QOpenGLVertexArrayObject vao_;
+  QOpenGLBuffer vbo_;
+
+  size_t num_geoms_;
+};
+
+}  // namespace colmap

--- a/src/colmap/ui/point_painter.h
+++ b/src/colmap/ui/point_painter.h
@@ -29,16 +29,18 @@
 
 #pragma once
 
+#include "colmap/ui/painter_base.h"
+
 #include <QtCore>
 #include <QtOpenGL>
 #include <cstdint>
 
 namespace colmap {
 
-class PointPainter {
+class PointPainter : public PainterBase {
  public:
-  PointPainter();
-  ~PointPainter();
+  PointPainter() = default;
+  ~PointPainter() = default;
 
   struct Data {
     Data() : x(0), y(0), z(0), r(0), g(0), b(0), a(0) {}
@@ -52,13 +54,6 @@ class PointPainter {
   void Setup();
   void Upload(const std::vector<PointPainter::Data>& data);
   void Render(const QMatrix4x4& pmv_matrix, float point_size);
-
- private:
-  QOpenGLShaderProgram shader_program_;
-  QOpenGLVertexArrayObject vao_;
-  QOpenGLBuffer vbo_;
-
-  size_t num_geoms_;
 };
 
 }  // namespace colmap

--- a/src/colmap/ui/triangle_painter.cc
+++ b/src/colmap/ui/triangle_painter.cc
@@ -29,101 +29,27 @@
 
 #include "colmap/ui/triangle_painter.h"
 
-#include "colmap/util/opengl_utils.h"
-
 namespace colmap {
 
-TrianglePainter::TrianglePainter() : num_geoms_(0) {}
-
-TrianglePainter::~TrianglePainter() {
-  vao_.destroy();
-  vbo_.destroy();
-}
-
 void TrianglePainter::Setup() {
-  vao_.destroy();
-  vbo_.destroy();
-  if (shader_program_.isLinked()) {
-    shader_program_.release();
-    shader_program_.removeAllShaders();
-  }
-
-  shader_program_.addShaderFromSourceFile(QOpenGLShader::Vertex,
-                                          ":/shaders/triangles.v.glsl");
-  shader_program_.addShaderFromSourceFile(QOpenGLShader::Fragment,
-                                          ":/shaders/triangles.f.glsl");
-  shader_program_.link();
-  shader_program_.bind();
-
-  vao_.create();
-  vbo_.create();
-
-#if DEBUG
-  glDebugLog();
-#endif
+  SetupShaders({{QOpenGLShader::Vertex, ":/shaders/triangles.v.glsl"},
+                {QOpenGLShader::Fragment, ":/shaders/triangles.f.glsl"}});
 }
 
 void TrianglePainter::Upload(const std::vector<TrianglePainter::Data>& data) {
-  num_geoms_ = data.size();
-  if (num_geoms_ == 0) {
-    return;
-  }
-
-  vao_.bind();
-  vbo_.bind();
-
-  // Upload data array to GPU
-  vbo_.setUsagePattern(QOpenGLBuffer::DynamicDraw);
-  vbo_.allocate(data.data(),
-                static_cast<int>(data.size() * sizeof(TrianglePainter::Data)));
-
-  // in_position
-  shader_program_.enableAttributeArray("a_position");
-  shader_program_.setAttributeBuffer(
-      "a_position", GL_FLOAT, 0, 3, sizeof(PointPainter::Data));
-
-  // in_color: use glVertexAttribPointer directly because Qt's
-  // setAttributeBuffer does not support the normalized parameter,
-  // which is needed to map uint8 [0,255] to float [0.0,1.0] in the shader.
-  shader_program_.enableAttributeArray("a_color");
-  QOpenGLFunctions* gl_funcs = QOpenGLContext::currentContext()->functions();
-  gl_funcs->glVertexAttribPointer(
-      shader_program_.attributeLocation("a_color"),
-      4,
-      GL_UNSIGNED_BYTE,
-      GL_TRUE,
-      sizeof(PointPainter::Data),
-      reinterpret_cast<const void*>(  // NOLINT(performance-no-int-to-ptr)
-          3 * sizeof(GLfloat)));
-
-  // Make sure they are not changed from the outside
-  vbo_.release();
-  vao_.release();
-
-#if DEBUG
-  glDebugLog();
-#endif
+  UploadGeoms(data, "a_position", sizeof(PointPainter::Data));
 }
 
 void TrianglePainter::Render(const QMatrix4x4& pmv_matrix) {
-  if (num_geoms_ == 0) {
+  if (!BeginRender()) {
     return;
   }
 
-  shader_program_.bind();
-  vao_.bind();
-
   shader_program_.setUniformValue("u_pmv_matrix", pmv_matrix);
 
-  QOpenGLFunctions* gl_funcs = QOpenGLContext::currentContext()->functions();
-  gl_funcs->glDrawArrays(GL_TRIANGLES, 0, (GLsizei)(3 * num_geoms_));
+  GLFunctions()->glDrawArrays(GL_TRIANGLES, 0, (GLsizei)(3 * num_geoms_));
 
-  // Make sure the VAO is not changed from the outside
-  vao_.release();
-
-#if DEBUG
-  glDebugLog();
-#endif
+  EndRender();
 }
 
 }  // namespace colmap

--- a/src/colmap/ui/triangle_painter.h
+++ b/src/colmap/ui/triangle_painter.h
@@ -36,10 +36,10 @@
 
 namespace colmap {
 
-class TrianglePainter {
+class TrianglePainter : public PainterBase {
  public:
-  TrianglePainter();
-  ~TrianglePainter();
+  TrianglePainter() = default;
+  ~TrianglePainter() = default;
 
   struct Data {
     Data() {}
@@ -56,13 +56,6 @@ class TrianglePainter {
   void Setup();
   void Upload(const std::vector<TrianglePainter::Data>& data);
   void Render(const QMatrix4x4& pmv_matrix);
-
- private:
-  QOpenGLShaderProgram shader_program_;
-  QOpenGLVertexArrayObject vao_;
-  QOpenGLBuffer vbo_;
-
-  size_t num_geoms_;
 };
 
 }  // namespace colmap


### PR DESCRIPTION
Point, line, triangle, and mesh painters shared near-identical OpenGL setup/upload/render boilerplate. This moves the common logic (shader setup, VAO/VBO management, vertex attribute binding, render bind/release) into a new `PainterBase` class. Public `Setup`/`Upload`/`Render` APIs are unchanged.

Stack 1/3 (no dependencies).

Test plan: `cmake --build build --target colmap_ui` passes; full `colmap` executable links.