### PR TITLE
Deduplicate UI option-widget row builders

### DIFF
--- a/src/colmap/ui/automatic_reconstruction_widget.cc
+++ b/src/colmap/ui/automatic_reconstruction_widget.cc
@@ -53,21 +53,11 @@ AutomaticReconstructionWidget::AutomaticReconstructionWidget(
 
   AddSpacer();
 
-  QLabel* data_type_label = new QLabel(tr("Data type"), this);
-  data_type_label->setFont(font());
-  data_type_label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-  grid_layout_->addWidget(data_type_label, grid_layout_->rowCount(), 0);
-
   data_type_cb_ = new QComboBox(this);
   data_type_cb_->addItem("Individual images");
   data_type_cb_->addItem("Video frames");
   data_type_cb_->addItem("Internet images");
-  grid_layout_->addWidget(data_type_cb_, grid_layout_->rowCount() - 1, 1);
-
-  QLabel* quality_label = new QLabel(tr("Quality"), this);
-  quality_label->setFont(font());
-  quality_label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-  grid_layout_->addWidget(quality_label, grid_layout_->rowCount(), 0);
+  AddWidgetRow("Data type", data_type_cb_);
 
   quality_cb_ = new QComboBox(this);
   quality_cb_->addItem("Low");
@@ -75,7 +65,7 @@ AutomaticReconstructionWidget::AutomaticReconstructionWidget(
   quality_cb_->addItem("High");
   quality_cb_->addItem("Extreme");
   quality_cb_->setCurrentIndex(2);
-  grid_layout_->addWidget(quality_cb_, grid_layout_->rowCount() - 1, 1);
+  AddWidgetRow("Quality", quality_cb_);
 
   AddSpacer();
 
@@ -85,16 +75,11 @@ AutomaticReconstructionWidget::AutomaticReconstructionWidget(
   AddOptionBool(&options_.sparse, "Sparse model");
   AddOptionBool(&options_.dense, "Dense model");
 
-  QLabel* mesher_label = new QLabel(tr("Mesher"), this);
-  mesher_label->setFont(font());
-  mesher_label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-  grid_layout_->addWidget(mesher_label, grid_layout_->rowCount(), 0);
-
   mesher_cb_ = new QComboBox(this);
   mesher_cb_->addItem("Poisson");
   mesher_cb_->addItem("Delaunay");
   mesher_cb_->setCurrentIndex(0);
-  grid_layout_->addWidget(mesher_cb_, grid_layout_->rowCount() - 1, 1);
+  AddWidgetRow("Mesher", mesher_cb_);
 
   AddSpacer();
 

--- a/src/colmap/ui/dense_reconstruction_widget.cc
+++ b/src/colmap/ui/dense_reconstruction_widget.cc
@@ -48,6 +48,15 @@ const static std::string kPoissonMeshedFileName = "meshed-poisson.ply";
 const static std::string kDelaunayMeshedFileName = "meshed-delaunay.ply";
 
 #if defined(COLMAP_MVS_ENABLED)
+void AddCacheSizeOption(OptionsWidget* widget, double* cache_size) {
+  widget->AddOptionDouble(cache_size,
+                          "cache_size [gigabytes]",
+                          0,
+                          std::numeric_limits<double>::max(),
+                          0.1,
+                          1);
+}
+
 class StereoOptionsTab : public OptionsWidget {
  public:
   StereoOptionsTab(QWidget* parent, OptionManager* options)
@@ -92,12 +101,7 @@ class StereoOptionsTab : public OptionsWidget {
     AddOptionDouble(
         &options->patch_match_stereo->filter_geom_consistency_max_cost,
         "filter_geom_consistency_max_cost");
-    AddOptionDouble(&options->patch_match_stereo->cache_size,
-                    "cache_size [gigabytes]",
-                    0,
-                    std::numeric_limits<double>::max(),
-                    0.1,
-                    1);
+    AddCacheSizeOption(this, &options->patch_match_stereo->cache_size);
     AddOptionBool(&options->patch_match_stereo->write_consistency_graph,
                   "write_consistency_graph");
     AddOptionInt(&options->patch_match_stereo->num_threads, "num_threads", -1);
@@ -125,12 +129,7 @@ class FusionOptionsTab : public OptionsWidget {
         &options->stereo_fusion->max_normal_error, "max_normal_error", 0, 180);
     AddOptionInt(
         &options->stereo_fusion->check_num_images, "check_num_images", 1);
-    AddOptionDouble(&options->stereo_fusion->cache_size,
-                    "cache_size [gigabytes]",
-                    0,
-                    std::numeric_limits<double>::max(),
-                    0.1,
-                    1);
+    AddCacheSizeOption(this, &options->stereo_fusion->cache_size);
     AddOptionBool(&options->stereo_fusion->use_cache, "use_cache");
   }
 };
@@ -234,40 +233,23 @@ DenseReconstructionWidget::DenseReconstructionWidget(MainWindow* main_window,
 
   QGridLayout* grid = new QGridLayout(this);
 
-  undistortion_button_ = new QPushButton(tr("Undistortion"), this);
-  connect(undistortion_button_,
-          &QPushButton::released,
-          this,
-          &DenseReconstructionWidget::Undistort);
-  grid->addWidget(undistortion_button_, 0, 0, Qt::AlignLeft);
+  auto AddButton = [this, grid](const char* label,
+                                int col,
+                                void (DenseReconstructionWidget::*slot)()) {
+    QPushButton* button = new QPushButton(tr(label), this);
+    connect(button, &QPushButton::released, this, slot);
+    grid->addWidget(button, 0, col, Qt::AlignLeft);
+    return button;
+  };
 
-  stereo_button_ = new QPushButton(tr("Stereo"), this);
-  connect(stereo_button_,
-          &QPushButton::released,
-          this,
-          &DenseReconstructionWidget::Stereo);
-  grid->addWidget(stereo_button_, 0, 1, Qt::AlignLeft);
-
-  fusion_button_ = new QPushButton(tr("Fusion"), this);
-  connect(fusion_button_,
-          &QPushButton::released,
-          this,
-          &DenseReconstructionWidget::Fusion);
-  grid->addWidget(fusion_button_, 0, 2, Qt::AlignLeft);
-
-  poisson_meshing_button_ = new QPushButton(tr("Poisson"), this);
-  connect(poisson_meshing_button_,
-          &QPushButton::released,
-          this,
-          &DenseReconstructionWidget::PoissonMeshing);
-  grid->addWidget(poisson_meshing_button_, 0, 3, Qt::AlignLeft);
-
-  delaunay_meshing_button_ = new QPushButton(tr("Delaunay"), this);
-  connect(delaunay_meshing_button_,
-          &QPushButton::released,
-          this,
-          &DenseReconstructionWidget::DelaunayMeshing);
-  grid->addWidget(delaunay_meshing_button_, 0, 4, Qt::AlignLeft);
+  undistortion_button_ =
+      AddButton("Undistortion", 0, &DenseReconstructionWidget::Undistort);
+  stereo_button_ = AddButton("Stereo", 1, &DenseReconstructionWidget::Stereo);
+  fusion_button_ = AddButton("Fusion", 2, &DenseReconstructionWidget::Fusion);
+  poisson_meshing_button_ =
+      AddButton("Poisson", 3, &DenseReconstructionWidget::PoissonMeshing);
+  delaunay_meshing_button_ =
+      AddButton("Delaunay", 4, &DenseReconstructionWidget::DelaunayMeshing);
 
   QPushButton* options_button = new QPushButton(tr("Options"), this);
   connect(options_button,

--- a/src/colmap/ui/feature_extraction_widget.cc
+++ b/src/colmap/ui/feature_extraction_widget.cc
@@ -49,6 +49,13 @@ class ExtractionWidget : public OptionsWidget {
   virtual void Run() = 0;
 
  protected:
+  void AddSharedOptions();
+  QComboBox* AddModelVariantRow(
+      const std::string& label_text,
+      std::initializer_list<std::pair<const char*, FeatureExtractorType>>
+          variants);
+  void RunExtraction();
+
   OptionManager* options_;
   ThreadControlWidget* thread_control_widget_;
 };
@@ -97,17 +104,46 @@ ExtractionWidget::ExtractionWidget(QWidget* parent, OptionManager* options)
       options_(options),
       thread_control_widget_(new ThreadControlWidget(this)) {}
 
+void ExtractionWidget::AddSharedOptions() {
+  AddOptionDirPath(&options_->image_reader->mask_path, "mask_path");
+  AddOptionFilePath(&options_->image_reader->camera_mask_path,
+                    "camera_mask_path");
+
+  AddOptionInt(&options_->feature_extraction->max_image_size, "max_image_size");
+  AddOptionInt(&options_->feature_extraction->num_threads, "num_threads", -1);
+  AddOptionBool(&options_->feature_extraction->use_gpu, "use_gpu");
+  AddOptionText(&options_->feature_extraction->gpu_index, "gpu_index");
+}
+
+QComboBox* ExtractionWidget::AddModelVariantRow(
+    const std::string& label_text,
+    std::initializer_list<std::pair<const char*, FeatureExtractorType>>
+        variants) {
+  QComboBox* combo_box = new QComboBox(this);
+  for (const auto& [label, type] : variants) {
+    combo_box->addItem(label, static_cast<int>(type));
+  }
+  AddWidgetRow(label_text, combo_box);
+  return combo_box;
+}
+
+void ExtractionWidget::RunExtraction() {
+  WriteOptions();
+
+  ImageReaderOptions reader_options = *options_->image_reader;
+  reader_options.image_path = *options_->image_path;
+  reader_options.as_rgb = options_->feature_extraction->RequiresRGB();
+
+  auto extractor = CreateFeatureExtractorController(
+      *options_->database_path, reader_options, *options_->feature_extraction);
+  thread_control_widget_->StartThread(
+      "Extracting...", true, std::move(extractor));
+}
+
 SIFTExtractionWidget::SIFTExtractionWidget(QWidget* parent,
                                            OptionManager* options)
     : ExtractionWidget(parent, options) {
-  AddOptionDirPath(&options->image_reader->mask_path, "mask_path");
-  AddOptionFilePath(&options->image_reader->camera_mask_path,
-                    "camera_mask_path");
-
-  AddOptionInt(&options->feature_extraction->max_image_size, "max_image_size");
-  AddOptionInt(&options->feature_extraction->num_threads, "num_threads", -1);
-  AddOptionBool(&options->feature_extraction->use_gpu, "use_gpu");
-  AddOptionText(&options->feature_extraction->gpu_index, "gpu_index");
+  AddSharedOptions();
 
   SiftExtractionOptions& sift_options = *options->feature_extraction->sift;
   AddOptionInt(&sift_options.max_num_features, "sift.max_num_features");
@@ -134,18 +170,8 @@ SIFTExtractionWidget::SIFTExtractionWidget(QWidget* parent,
 }
 
 void SIFTExtractionWidget::Run() {
-  WriteOptions();
-
   options_->feature_extraction->type = FeatureExtractorType::SIFT;
-
-  ImageReaderOptions reader_options = *options_->image_reader;
-  reader_options.image_path = *options_->image_path;
-  reader_options.as_rgb = options_->feature_extraction->RequiresRGB();
-
-  auto extractor = CreateFeatureExtractorController(
-      *options_->database_path, reader_options, *options_->feature_extraction);
-  thread_control_widget_->StartThread(
-      "Extracting...", true, std::move(extractor));
+  RunExtraction();
 }
 
 ImportFeaturesWidget::ImportFeaturesWidget(QWidget* parent,
@@ -175,21 +201,12 @@ void ImportFeaturesWidget::Run() {
 AlikedExtractionWidget::AlikedExtractionWidget(QWidget* parent,
                                                OptionManager* options)
     : ExtractionWidget(parent, options) {
-  AddOptionDirPath(&options->image_reader->mask_path, "mask_path");
-  AddOptionFilePath(&options->image_reader->camera_mask_path,
-                    "camera_mask_path");
+  AddSharedOptions();
 
-  AddOptionInt(&options->feature_extraction->max_image_size, "max_image_size");
-  AddOptionInt(&options->feature_extraction->num_threads, "num_threads", -1);
-  AddOptionBool(&options->feature_extraction->use_gpu, "use_gpu");
-  AddOptionText(&options->feature_extraction->gpu_index, "gpu_index");
-
-  model_variant_cb_ = new QComboBox(this);
-  model_variant_cb_->addItem(
-      "n16rot", static_cast<int>(FeatureExtractorType::ALIKED_N16ROT));
-  model_variant_cb_->addItem(
-      "n32", static_cast<int>(FeatureExtractorType::ALIKED_N32));
-  AddWidgetRow("aliked.model_variant", model_variant_cb_);
+  model_variant_cb_ =
+      AddModelVariantRow("aliked.model_variant",
+                         {{"n16rot", FeatureExtractorType::ALIKED_N16ROT},
+                          {"n32", FeatureExtractorType::ALIKED_N32}});
 
   AlikedExtractionOptions& aliked_options =
       *options->feature_extraction->aliked;
@@ -200,39 +217,20 @@ AlikedExtractionWidget::AlikedExtractionWidget(QWidget* parent,
 }
 
 void AlikedExtractionWidget::Run() {
-  WriteOptions();
-
   options_->feature_extraction->type = static_cast<FeatureExtractorType>(
       model_variant_cb_->currentData().toInt());
-
-  ImageReaderOptions reader_options = *options_->image_reader;
-  reader_options.image_path = *options_->image_path;
-  reader_options.as_rgb = options_->feature_extraction->RequiresRGB();
-
-  auto extractor = CreateFeatureExtractorController(
-      *options_->database_path, reader_options, *options_->feature_extraction);
-  thread_control_widget_->StartThread(
-      "Extracting...", true, std::move(extractor));
+  RunExtraction();
 }
 
 LomaExtractionWidget::LomaExtractionWidget(QWidget* parent,
                                            OptionManager* options)
     : ExtractionWidget(parent, options) {
-  AddOptionDirPath(&options->image_reader->mask_path, "mask_path");
-  AddOptionFilePath(&options->image_reader->camera_mask_path,
-                    "camera_mask_path");
+  AddSharedOptions();
 
-  AddOptionInt(&options->feature_extraction->max_image_size, "max_image_size");
-  AddOptionInt(&options->feature_extraction->num_threads, "num_threads", -1);
-  AddOptionBool(&options->feature_extraction->use_gpu, "use_gpu");
-  AddOptionText(&options->feature_extraction->gpu_index, "gpu_index");
-
-  model_variant_cb_ = new QComboBox(this);
-  model_variant_cb_->addItem("B (dedode_g)",
-                             static_cast<int>(FeatureExtractorType::LOMA_B));
-  model_variant_cb_->addItem("B128 (dedode_b)",
-                             static_cast<int>(FeatureExtractorType::LOMA_B128));
-  AddWidgetRow("loma.model_variant", model_variant_cb_);
+  model_variant_cb_ = AddModelVariantRow(
+      "loma.model_variant",
+      {{"B (dedode_g)", FeatureExtractorType::LOMA_B},
+       {"B128 (dedode_b)", FeatureExtractorType::LOMA_B128}});
 
   LomaExtractionOptions& loma_options = *options->feature_extraction->loma;
   AddOptionInt(&loma_options.max_num_features, "loma.max_num_features");
@@ -249,19 +247,9 @@ LomaExtractionWidget::LomaExtractionWidget(QWidget* parent,
 }
 
 void LomaExtractionWidget::Run() {
-  WriteOptions();
-
   options_->feature_extraction->type = static_cast<FeatureExtractorType>(
       model_variant_cb_->currentData().toInt());
-
-  ImageReaderOptions reader_options = *options_->image_reader;
-  reader_options.image_path = *options_->image_path;
-  reader_options.as_rgb = options_->feature_extraction->RequiresRGB();
-
-  auto extractor = CreateFeatureExtractorController(
-      *options_->database_path, reader_options, *options_->feature_extraction);
-  thread_control_widget_->StartThread(
-      "Extracting...", true, std::move(extractor));
+  RunExtraction();
 }
 #endif
 
@@ -278,26 +266,19 @@ FeatureExtractionWidget::FeatureExtractionWidget(QWidget* parent,
 
   tab_widget_ = new QTabWidget(this);
 
-  QScrollArea* sift_widget = new QScrollArea(this);
-  sift_widget->setAlignment(Qt::AlignHCenter);
-  sift_widget->setWidget(new SIFTExtractionWidget(this, options));
-  tab_widget_->addTab(sift_widget, tr("SIFT"));
+  auto AddTab = [this](QWidget* widget, const char* title) {
+    QScrollArea* scroll_area = new QScrollArea(this);
+    scroll_area->setAlignment(Qt::AlignHCenter);
+    scroll_area->setWidget(widget);
+    tab_widget_->addTab(scroll_area, tr(title));
+  };
 
-  QScrollArea* import_widget = new QScrollArea(this);
-  import_widget->setAlignment(Qt::AlignHCenter);
-  import_widget->setWidget(new ImportFeaturesWidget(this, options));
-  tab_widget_->addTab(import_widget, tr("SIFT (Import)"));
+  AddTab(new SIFTExtractionWidget(this, options), "SIFT");
+  AddTab(new ImportFeaturesWidget(this, options), "SIFT (Import)");
 
 #ifdef COLMAP_ONNX_ENABLED
-  QScrollArea* aliked_widget = new QScrollArea(this);
-  aliked_widget->setAlignment(Qt::AlignHCenter);
-  aliked_widget->setWidget(new AlikedExtractionWidget(this, options));
-  tab_widget_->addTab(aliked_widget, tr("ALIKED"));
-
-  QScrollArea* loma_widget = new QScrollArea(this);
-  loma_widget->setAlignment(Qt::AlignHCenter);
-  loma_widget->setWidget(new LomaExtractionWidget(this, options));
-  tab_widget_->addTab(loma_widget, tr("LoMa"));
+  AddTab(new AlikedExtractionWidget(this, options), "ALIKED");
+  AddTab(new LomaExtractionWidget(this, options), "LoMa");
 #endif
 
   grid->addWidget(tab_widget_);

--- a/src/colmap/ui/feature_matching_widget.cc
+++ b/src/colmap/ui/feature_matching_widget.cc
@@ -55,6 +55,7 @@ class FeatureMatchingTab : public QWidget {
   void ReadOptions();
   void WriteOptions();
   void CreateGeneralOptions();
+  void RunMatcher(std::unique_ptr<Thread> matcher);
 
   OptionManager* options_;
   OptionsWidget* options_widget_;
@@ -224,6 +225,22 @@ void FeatureMatchingTab::WriteOptions() {
       matcher_types_[matcher_type_cb_->currentIndex()];
 }
 
+void FeatureMatchingTab::RunMatcher(std::unique_ptr<Thread> matcher) {
+  WriteOptions();
+  thread_control_widget_->StartThread("Matching...", true, std::move(matcher));
+}
+
+// An empty path is valid: the matcher then resolves the default vocabulary
+// tree for the database's feature type via GetVocabTreeUriForFeatureType.
+bool CheckVocabTreePath(QWidget* parent, const std::filesystem::path& path) {
+  if (!path.empty() && !ExistsFile(path) && !IsURI(path.string())) {
+    QMessageBox::critical(
+        parent, "", parent->tr("Invalid vocabulary tree path."));
+    return false;
+  }
+  return true;
+}
+
 ExhaustiveMatchingTab::ExhaustiveMatchingTab(QWidget* parent,
                                              OptionManager* options)
     : FeatureMatchingTab(parent, options) {
@@ -234,13 +251,10 @@ ExhaustiveMatchingTab::ExhaustiveMatchingTab(QWidget* parent,
 }
 
 void ExhaustiveMatchingTab::Run() {
-  WriteOptions();
-
-  auto matcher = CreateExhaustiveFeatureMatcher(*options_->exhaustive_pairing,
-                                                *options_->feature_matching,
-                                                *options_->two_view_geometry,
-                                                *options_->database_path);
-  thread_control_widget_->StartThread("Matching...", true, std::move(matcher));
+  RunMatcher(CreateExhaustiveFeatureMatcher(*options_->exhaustive_pairing,
+                                            *options_->feature_matching,
+                                            *options_->two_view_geometry,
+                                            *options_->database_path));
 }
 
 SequentialMatchingTab::SequentialMatchingTab(QWidget* parent,
@@ -287,21 +301,16 @@ SequentialMatchingTab::SequentialMatchingTab(QWidget* parent,
 void SequentialMatchingTab::Run() {
   WriteOptions();
 
-  // An empty path is valid: the matcher then resolves the default vocabulary
-  // tree for the database's feature type via GetVocabTreeUriForFeatureType.
   if (options_->sequential_pairing->loop_detection &&
-      !options_->sequential_pairing->vocab_tree_path.empty() &&
-      !ExistsFile(options_->sequential_pairing->vocab_tree_path) &&
-      !IsURI(options_->sequential_pairing->vocab_tree_path.string())) {
-    QMessageBox::critical(this, "", tr("Invalid vocabulary tree path."));
+      !CheckVocabTreePath(this,
+                          options_->sequential_pairing->vocab_tree_path)) {
     return;
   }
 
-  auto matcher = CreateSequentialFeatureMatcher(*options_->sequential_pairing,
-                                                *options_->feature_matching,
-                                                *options_->two_view_geometry,
-                                                *options_->database_path);
-  thread_control_widget_->StartThread("Matching...", true, std::move(matcher));
+  RunMatcher(CreateSequentialFeatureMatcher(*options_->sequential_pairing,
+                                            *options_->feature_matching,
+                                            *options_->two_view_geometry,
+                                            *options_->database_path));
 }
 
 VocabTreeMatchingTab::VocabTreeMatchingTab(QWidget* parent,
@@ -329,20 +338,15 @@ VocabTreeMatchingTab::VocabTreeMatchingTab(QWidget* parent,
 void VocabTreeMatchingTab::Run() {
   WriteOptions();
 
-  // An empty path is valid: the matcher then resolves the default vocabulary
-  // tree for the database's feature type via GetVocabTreeUriForFeatureType.
-  if (!options_->vocab_tree_pairing->vocab_tree_path.empty() &&
-      !ExistsFile(options_->vocab_tree_pairing->vocab_tree_path) &&
-      !IsURI(options_->vocab_tree_pairing->vocab_tree_path.string())) {
-    QMessageBox::critical(this, "", tr("Invalid vocabulary tree path."));
+  if (!CheckVocabTreePath(this,
+                          options_->vocab_tree_pairing->vocab_tree_path)) {
     return;
   }
 
-  auto matcher = CreateVocabTreeFeatureMatcher(*options_->vocab_tree_pairing,
-                                               *options_->feature_matching,
-                                               *options_->two_view_geometry,
-                                               *options_->database_path);
-  thread_control_widget_->StartThread("Matching...", true, std::move(matcher));
+  RunMatcher(CreateVocabTreeFeatureMatcher(*options_->vocab_tree_pairing,
+                                           *options_->feature_matching,
+                                           *options_->two_view_geometry,
+                                           *options_->database_path));
 }
 
 SpatialMatchingTab::SpatialMatchingTab(QWidget* parent, OptionManager* options)
@@ -360,13 +364,10 @@ SpatialMatchingTab::SpatialMatchingTab(QWidget* parent, OptionManager* options)
 }
 
 void SpatialMatchingTab::Run() {
-  WriteOptions();
-
-  auto matcher = CreateSpatialFeatureMatcher(*options_->spatial_pairing,
-                                             *options_->feature_matching,
-                                             *options_->two_view_geometry,
-                                             *options_->database_path);
-  thread_control_widget_->StartThread("Matching...", true, std::move(matcher));
+  RunMatcher(CreateSpatialFeatureMatcher(*options_->spatial_pairing,
+                                         *options_->feature_matching,
+                                         *options_->two_view_geometry,
+                                         *options_->database_path));
 }
 
 TransitiveMatchingTab::TransitiveMatchingTab(QWidget* parent,
@@ -381,13 +382,10 @@ TransitiveMatchingTab::TransitiveMatchingTab(QWidget* parent,
 }
 
 void TransitiveMatchingTab::Run() {
-  WriteOptions();
-
-  auto matcher = CreateTransitiveFeatureMatcher(*options_->transitive_pairing,
-                                                *options_->feature_matching,
-                                                *options_->two_view_geometry,
-                                                *options_->database_path);
-  thread_control_widget_->StartThread("Matching...", true, std::move(matcher));
+  RunMatcher(CreateTransitiveFeatureMatcher(*options_->transitive_pairing,
+                                            *options_->feature_matching,
+                                            *options_->two_view_geometry,
+                                            *options_->database_path));
 }
 
 CustomMatchingTab::CustomMatchingTab(QWidget* parent, OptionManager* options)
@@ -437,7 +435,7 @@ void CustomMatchingTab::Run() {
                                                *options_->database_path);
   }
 
-  thread_control_widget_->StartThread("Matching...", true, std::move(matcher));
+  RunMatcher(std::move(matcher));
 }
 
 FeatureMatchingWidget::FeatureMatchingWidget(QWidget* parent,

--- a/src/colmap/ui/feature_matching_widget.cc
+++ b/src/colmap/ui/feature_matching_widget.cc
@@ -226,7 +226,6 @@ void FeatureMatchingTab::WriteOptions() {
 }
 
 void FeatureMatchingTab::RunMatcher(std::unique_ptr<Thread> matcher) {
-  WriteOptions();
   thread_control_widget_->StartThread("Matching...", true, std::move(matcher));
 }
 
@@ -251,6 +250,8 @@ ExhaustiveMatchingTab::ExhaustiveMatchingTab(QWidget* parent,
 }
 
 void ExhaustiveMatchingTab::Run() {
+  WriteOptions();
+
   RunMatcher(CreateExhaustiveFeatureMatcher(*options_->exhaustive_pairing,
                                             *options_->feature_matching,
                                             *options_->two_view_geometry,
@@ -364,6 +365,8 @@ SpatialMatchingTab::SpatialMatchingTab(QWidget* parent, OptionManager* options)
 }
 
 void SpatialMatchingTab::Run() {
+  WriteOptions();
+
   RunMatcher(CreateSpatialFeatureMatcher(*options_->spatial_pairing,
                                          *options_->feature_matching,
                                          *options_->two_view_geometry,
@@ -382,6 +385,8 @@ TransitiveMatchingTab::TransitiveMatchingTab(QWidget* parent,
 }
 
 void TransitiveMatchingTab::Run() {
+  WriteOptions();
+
   RunMatcher(CreateTransitiveFeatureMatcher(*options_->transitive_pairing,
                                             *options_->feature_matching,
                                             *options_->two_view_geometry,

--- a/src/colmap/ui/options_widget.cc
+++ b/src/colmap/ui/options_widget.cc
@@ -58,16 +58,22 @@ OptionsWidget::OptionsWidget(QWidget* parent) : QWidget(parent) {
   setLayout(grid_layout_);
 }
 
-void OptionsWidget::AddOptionRow(const std::string& label_text,
-                                 QWidget* widget,
-                                 void* option) {
+QLabel* OptionsWidget::CreateRowLabel(const std::string& label_text) {
   QLabel* label = new QLabel(tr(label_text.c_str()), this);
   label->setFont(font());
   label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-  grid_layout_->addWidget(label, grid_layout_->rowCount(), 0);
+  return label;
+}
+
+void OptionsWidget::AddOptionRow(const std::string& label_text,
+                                 QWidget* widget,
+                                 void* option) {
+  QLabel* label = CreateRowLabel(label_text);
+  const int row = grid_layout_->rowCount();
+  grid_layout_->addWidget(label, row, 0);
 
   widget->setFont(font());
-  grid_layout_->addWidget(widget, grid_layout_->rowCount() - 1, 1);
+  grid_layout_->addWidget(widget, row, 1);
 
   option_rows_.emplace(option, std::make_pair(label, widget));
   widget_rows_.emplace(widget, std::make_pair(label, widget));
@@ -75,29 +81,27 @@ void OptionsWidget::AddOptionRow(const std::string& label_text,
 
 void OptionsWidget::AddWidgetRow(const std::string& label_text,
                                  QWidget* widget) {
-  QLabel* label = new QLabel(tr(label_text.c_str()), this);
-  label->setFont(font());
-  label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-  grid_layout_->addWidget(label, grid_layout_->rowCount(), 0);
+  QLabel* label = CreateRowLabel(label_text);
+  const int row = grid_layout_->rowCount();
+  grid_layout_->addWidget(label, row, 0);
 
   widget->setFont(font());
-  grid_layout_->addWidget(widget, grid_layout_->rowCount() - 1, 1);
+  grid_layout_->addWidget(widget, row, 1);
 
   widget_rows_.emplace(widget, std::make_pair(label, widget));
 }
 
 void OptionsWidget::AddLayoutRow(const std::string& label_text,
                                  QLayout* layout) {
-  QLabel* label = new QLabel(tr(label_text.c_str()), this);
-  label->setFont(font());
-  label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-  grid_layout_->addWidget(label, grid_layout_->rowCount(), 0);
+  QLabel* label = CreateRowLabel(label_text);
+  const int row = grid_layout_->rowCount();
+  grid_layout_->addWidget(label, row, 0);
 
   QWidget* layout_widget = new QWidget(this);
   layout_widget->setLayout(layout);
   layout->setContentsMargins(0, 0, 0, 0);
 
-  grid_layout_->addWidget(layout_widget, grid_layout_->rowCount() - 1, 1);
+  grid_layout_->addWidget(layout_widget, row, 1);
 
   layout_rows_.emplace(layout, std::make_pair(label, layout_widget));
 }
@@ -198,18 +202,22 @@ QLineEdit* OptionsWidget::AddOptionText(std::string* option,
   return line_edit;
 }
 
-QLineEdit* OptionsWidget::AddOptionFilePath(std::filesystem::path* option,
-                                            const std::string& label_text) {
+QLineEdit* OptionsWidget::AddOptionPath(std::filesystem::path* option,
+                                        const std::string& label_text,
+                                        bool directory) {
   QLineEdit* line_edit = new QLineEdit(this);
   line_edit->setText(QString::fromStdString(option->string()));
 
   AddOptionRow(label_text, line_edit, option);
 
-  auto SelectPathFunc = [this, line_edit]() {
-    line_edit->setText(QFileDialog::getOpenFileName(this, tr("Select file")));
+  auto SelectPathFunc = [this, line_edit, directory]() {
+    line_edit->setText(
+        directory ? QFileDialog::getExistingDirectory(this, tr("Select folder"))
+                  : QFileDialog::getOpenFileName(this, tr("Select file")));
   };
 
-  QPushButton* select_button = new QPushButton(tr("Select file"), this);
+  QPushButton* select_button = new QPushButton(
+      directory ? tr("Select folder") : tr("Select file"), this);
   select_button->setFont(font());
   connect(select_button, &QPushButton::released, this, SelectPathFunc);
   grid_layout_->addWidget(select_button, grid_layout_->rowCount(), 1);
@@ -219,26 +227,14 @@ QLineEdit* OptionsWidget::AddOptionFilePath(std::filesystem::path* option,
   return line_edit;
 }
 
+QLineEdit* OptionsWidget::AddOptionFilePath(std::filesystem::path* option,
+                                            const std::string& label_text) {
+  return AddOptionPath(option, label_text, /*directory=*/false);
+}
+
 QLineEdit* OptionsWidget::AddOptionDirPath(std::filesystem::path* option,
                                            const std::string& label_text) {
-  QLineEdit* line_edit = new QLineEdit(this);
-  line_edit->setText(QString::fromStdString(option->string()));
-
-  AddOptionRow(label_text, line_edit, option);
-
-  auto SelectPathFunc = [this, line_edit]() {
-    line_edit->setText(
-        QFileDialog::getExistingDirectory(this, tr("Select folder")));
-  };
-
-  QPushButton* select_button = new QPushButton(tr("Select folder"), this);
-  select_button->setFont(font());
-  connect(select_button, &QPushButton::released, this, SelectPathFunc);
-  grid_layout_->addWidget(select_button, grid_layout_->rowCount(), 1);
-
-  options_path_.emplace_back(line_edit, option);
-
-  return line_edit;
+  return AddOptionPath(option, label_text, /*directory=*/true);
 }
 
 void OptionsWidget::AddSpacer() {
@@ -323,39 +319,27 @@ void OptionsWidget::closeEvent(QCloseEvent* event) { WriteOptions(); }
 void OptionsWidget::hideEvent(QHideEvent* event) { WriteOptions(); }
 
 void OptionsWidget::ShowOption(void* option) {
-  auto& option_row = option_rows_.at(option);
-  option_row.first->show();
-  option_row.second->show();
+  SetRowVisible(option_rows_, option, /*visible=*/true);
 }
 
 void OptionsWidget::HideOption(void* option) {
-  auto& option_row = option_rows_.at(option);
-  option_row.first->hide();
-  option_row.second->hide();
+  SetRowVisible(option_rows_, option, /*visible=*/false);
 }
 
 void OptionsWidget::ShowWidget(QWidget* widget) {
-  auto& widget_row = widget_rows_.at(widget);
-  widget_row.first->show();
-  widget_row.second->show();
+  SetRowVisible(widget_rows_, widget, /*visible=*/true);
 }
 
 void OptionsWidget::HideWidget(QWidget* widget) {
-  auto& widget_row = widget_rows_.at(widget);
-  widget_row.first->hide();
-  widget_row.second->hide();
+  SetRowVisible(widget_rows_, widget, /*visible=*/false);
 }
 
 void OptionsWidget::ShowLayout(QLayout* layout) {
-  auto& layout_row = layout_rows_.at(layout);
-  layout_row.first->show();
-  layout_row.second->show();
+  SetRowVisible(layout_rows_, layout, /*visible=*/true);
 }
 
 void OptionsWidget::HideLayout(QLayout* layout) {
-  auto& layout_row = layout_rows_.at(layout);
-  layout_row.first->hide();
-  layout_row.second->hide();
+  SetRowVisible(layout_rows_, layout, /*visible=*/false);
 }
 
 }  // namespace colmap

--- a/src/colmap/ui/options_widget.h
+++ b/src/colmap/ui/options_widget.h
@@ -110,6 +110,22 @@ class OptionsWidget : public QWidget {
   std::vector<std::pair<QCheckBox*, bool*>> options_bool_;
   std::vector<std::pair<QLineEdit*, std::string*>> options_text_;
   std::vector<std::pair<QLineEdit*, std::filesystem::path*>> options_path_;
+
+ private:
+  QLabel* CreateRowLabel(const std::string& label_text);
+  QLineEdit* AddOptionPath(std::filesystem::path* option,
+                           const std::string& label_text,
+                           bool directory);
+
+  template <typename Key>
+  static void SetRowVisible(
+      NodeHashMap<Key, std::pair<QLabel*, QWidget*>>& rows,
+      const Key& key,
+      bool visible) {
+    auto& row = rows.at(key);
+    row.first->setVisible(visible);
+    row.second->setVisible(visible);
+  }
 };
 
 }  // namespace colmap


### PR DESCRIPTION
Shares label/row creation (`CreateRowLabel`), file/dir path rows (`AddOptionPath`), and row visibility (`SetRowVisible`) in `OptionsWidget`, and reuses them in the feature extraction/matching, dense reconstruction, and automatic reconstruction widgets via shared option blocks, matcher runners, and button/tab helpers. Qt ownership, signals, and layout are unchanged.

Stack 2/3, based on #4697 (mechanical stacking only; no code dependency).

Test plan: `cmake --build build --target colmap_ui` passes.