### PR TITLE
Deduplicate Jet-colormap conversions

### DIFF
--- a/src/colmap/mvs/depth_map.cc
+++ b/src/colmap/mvs/depth_map.cc
@@ -114,10 +114,7 @@ Bitmap DepthMap::ToBitmap(const float min_percentile,
             std::max(robust_depth_min, std::min(robust_depth_max, depth));
         const float gray =
             (robust_depth - robust_depth_min) / robust_depth_range;
-        const BitmapColor<float> color(255 * JetColormap::Red(gray),
-                                       255 * JetColormap::Green(gray),
-                                       255 * JetColormap::Blue(gray));
-        bitmap.SetPixel(x, y, color.Cast<uint8_t>());
+        bitmap.SetPixel(x, y, JetColormap::ToBitmapColor(gray));
       } else {
         bitmap.SetPixel(x, y, BitmapColor<uint8_t>(0));
       }

--- a/src/colmap/sensor/bitmap.cc
+++ b/src/colmap/sensor/bitmap.cc
@@ -732,6 +732,12 @@ float JetColormap::Green(const float gray) { return Base(gray); }
 
 float JetColormap::Blue(const float gray) { return Base(gray + 0.25f); }
 
+BitmapColor<uint8_t> JetColormap::ToBitmapColor(const float gray) {
+  return BitmapColor<float>(
+             255 * Red(gray), 255 * Green(gray), 255 * Blue(gray))
+      .Cast<uint8_t>();
+}
+
 float JetColormap::Base(const float val) {
   // NOLINTNEXTLINE(bugprone-branch-clone)
   if (val <= 0.125f) {

--- a/src/colmap/sensor/bitmap.h
+++ b/src/colmap/sensor/bitmap.h
@@ -203,6 +203,7 @@ class JetColormap {
   static float Red(float gray);
   static float Green(float gray);
   static float Blue(float gray);
+  static BitmapColor<uint8_t> ToBitmapColor(float gray);
 
  private:
   static float Interpolate(float val, float y0, float x0, float y1, float x1);

--- a/src/colmap/ui/colormaps.cc
+++ b/src/colmap/ui/colormaps.cc
@@ -33,6 +33,27 @@
 #include "colmap/util/hash_containers.h"
 
 namespace colmap {
+namespace {
+
+Eigen::Vector4f JetColorRGBA(float gray) {
+  return Eigen::Vector4f(JetColormap::Red(gray),
+                         JetColormap::Green(gray),
+                         JetColormap::Blue(gray),
+                         1.0f);
+}
+
+template <typename Func>
+std::vector<float> CollectValues(
+    const NodeHashMap<point3D_t, Point3D>& points3D, Func func) {
+  std::vector<float> values;
+  values.reserve(points3D.size());
+  for (const auto& point3D : points3D) {
+    values.push_back(func(point3D.second));
+  }
+  return values;
+}
+
+}  // namespace
 
 PointColormapBase::PointColormapBase()
     : scale(1.0f),
@@ -83,46 +104,29 @@ void PointColormapError::Prepare(NodeHashMap<camera_t, Camera>& cameras,
                                  NodeHashMap<image_t, Image>& images,
                                  NodeHashMap<point3D_t, Point3D>& points3D,
                                  std::vector<image_t>& reg_image_ids) {
-  std::vector<float> errors;
-  errors.reserve(points3D.size());
-
-  for (const auto& point3D : points3D) {
-    errors.push_back(static_cast<float>(point3D.second.error));
-  }
-
+  auto errors = CollectValues(points3D, [](const Point3D& point3D) {
+    return static_cast<float>(point3D.error);
+  });
   UpdateScale(&errors);
 }
 
 Eigen::Vector4f PointColormapError::ComputeColor(const point3D_t point3D_id,
                                                  const Point3D& point3D) {
-  const float gray = AdjustScale(static_cast<float>(point3D.error));
-  return Eigen::Vector4f(JetColormap::Red(gray),
-                         JetColormap::Green(gray),
-                         JetColormap::Blue(gray),
-                         1.0f);
+  return JetColorRGBA(AdjustScale(static_cast<float>(point3D.error)));
 }
 
 void PointColormapTrackLen::Prepare(NodeHashMap<camera_t, Camera>& cameras,
                                     NodeHashMap<image_t, Image>& images,
                                     NodeHashMap<point3D_t, Point3D>& points3D,
                                     std::vector<image_t>& reg_image_ids) {
-  std::vector<float> track_lengths;
-  track_lengths.reserve(points3D.size());
-
-  for (const auto& point3D : points3D) {
-    track_lengths.push_back(point3D.second.track.Length());
-  }
-
+  auto track_lengths = CollectValues(
+      points3D, [](const Point3D& point3D) { return point3D.track.Length(); });
   UpdateScale(&track_lengths);
 }
 
 Eigen::Vector4f PointColormapTrackLen::ComputeColor(const point3D_t point3D_id,
                                                     const Point3D& point3D) {
-  const float gray = AdjustScale(point3D.track.Length());
-  return Eigen::Vector4f(JetColormap::Red(gray),
-                         JetColormap::Green(gray),
-                         JetColormap::Blue(gray),
-                         1.0f);
+  return JetColorRGBA(AdjustScale(point3D.track.Length()));
 }
 
 void PointColormapGroundResolution::Prepare(
@@ -201,11 +205,7 @@ void PointColormapGroundResolution::Prepare(
 
 Eigen::Vector4f PointColormapGroundResolution::ComputeColor(
     const point3D_t point3D_id, const Point3D& point3D) {
-  const float gray = AdjustScale(resolutions_[point3D_id]);
-  return Eigen::Vector4f(JetColormap::Red(gray),
-                         JetColormap::Green(gray),
-                         JetColormap::Blue(gray),
-                         1.0f);
+  return JetColorRGBA(AdjustScale(resolutions_[point3D_id]));
 }
 
 const Eigen::Vector4f ImageColormapBase::kDefaultPlaneColor = {

--- a/src/colmap/ui/match_matrix_widget.cc
+++ b/src/colmap/ui/match_matrix_widget.cc
@@ -80,11 +80,9 @@ void MatchMatrixWidget::Show() {
       const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
       const size_t idx1 = image_id_to_idx.at(image_id1);
       const size_t idx2 = image_id_to_idx.at(image_id2);
-      const BitmapColor<float> color(255 * JetColormap::Red(value),
-                                     255 * JetColormap::Green(value),
-                                     255 * JetColormap::Blue(value));
-      match_matrix.SetPixel(idx1, idx2, color.Cast<uint8_t>());
-      match_matrix.SetPixel(idx2, idx1, color.Cast<uint8_t>());
+      const auto color = JetColormap::ToBitmapColor(value);
+      match_matrix.SetPixel(idx1, idx2, color);
+      match_matrix.SetPixel(idx2, idx1, color);
     }
   }
 


### PR DESCRIPTION
Adds `JetColormap::ToBitmapColor` for the repeated 255-scaled RGB construction in depth-map and match-matrix rendering, and shares the Eigen RGBA construction and value-collection loops in the UI point colormaps.

Stack 3/3, based on #4698 (mechanical stacking only; no code dependency).

Test plan: `ctest -R '(sensor/bitmap_test|mvs/depth_map_test)'` passes.