### PR TITLE
Point AGENTS.md at optional AGENTS.override.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ CMakeUserPresets.json
 .clangd
 compile_commands.json
 .claude/settings.local.json
+AGENTS.override.md
 
 # Custom directories
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md — COLMAP Guide
 
+If an optional `AGENTS.override.md` exists alongside this file, read it and follow it; its instructions take precedence over this file.
+
 ## Project Overview
 
 COLMAP is a general-purpose Structure-from-Motion (SfM) and Multi-View Stereo (MVS) pipeline that reconstructs 3D models from 2D image collections. Written in C++17 with optional CUDA support. Single binary (colmap) with many subcommands, a Qt GUI, and Python bindings (pycolmap).


### PR DESCRIPTION
Some agents don't respect AGENTS.overrid.md and thus loading AGENTS.md currently never see repo-local personal instructions. This one-liner tells them to also read AGENTS.override.md when present (kept out of git via .gitignore), with its instructions taking precedence over the shared guide. Useful for instructing the model about user-specific Python environments, etc.