### PR TITLE
Score grouped relative errors in sorted edge order

### DIFF
--- a/benchmark/reconstruction/evaluation/utils.py
+++ b/benchmark/reconstruction/evaluation/utils.py
@@ -1383,7 +1383,10 @@ def compute_grouped_rel_errors(
         gt_edges.update(itertools.permutations(group_names, 2))
 
     errors: list[float] = []
-    for edge in set(tgt_from_src_est_edges) | gt_edges:
+    # Score edges in sorted order: set iteration order depends on the
+    # per-process hash seed, so an unsorted union would permute the error
+    # array from run to run.
+    for edge in sorted(set(tgt_from_src_est_edges) | gt_edges):
         src_name, tgt_name = edge
         tgt_from_src_ests = tgt_from_src_est_edges.get(edge, [])
         if edge in gt_edges:


### PR DESCRIPTION
## Root cause

`compute_grouped_rel_errors` scored the edge union via `for edge in set(...) | gt_edges`. Set iteration order for string tuples depends on the per-process `PYTHONHASHSEED`, so the stored error array permuted run-to-run.

The sibling absolute path is not affected: `compute_grouped_abs_errors` flattens in GT image order, and pycolmap's `images.values()` order proved stable across processes for the same file.

## Change

- `benchmark/reconstruction/evaluation/utils.py`: score edges in `sorted(...)` order, with a comment explaining why. Metric values (recall/AUC) are order-invariant, so this only stabilizes the stored error arrays.

## Verification

- `scripts/format/python.sh`: clean.
- `pytest benchmark/reconstruction/evaluation/utils_test.py`: all pass, including under `PYTHONHASHSEED=1` and `PYTHONHASHSEED=2`.