### PR TITLE
Guard OpenMP runtime API calls with _OPENMP

### DIFF
--- a/src/colmap/controllers/pairing.cc
+++ b/src/colmap/controllers/pairing.cc
@@ -41,7 +41,9 @@
 #include <vector>
 
 #include <faiss/IndexFlat.h>
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 namespace colmap {
 namespace {
@@ -674,7 +676,9 @@ SpatialPairGenerator::SpatialPairGenerator(
   index_matrix_.resize(num_positions, knn_);
   distance_squared_matrix_.resize(num_positions, knn_);
 
+#ifdef _OPENMP
   omp_set_num_threads(GetEffectiveNumThreads(options_.num_threads));
+#endif
 
   search_index.search(position_matrix.rows(),
                       position_matrix.data(),

--- a/src/colmap/feature/index.cc
+++ b/src/colmap/feature/index.cc
@@ -36,7 +36,9 @@
 #include <faiss/IndexIVFPQ.h>
 #include <faiss/IndexPQ.h>
 #include <faiss/IndexScalarQuantizer.h>
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 namespace colmap {
 namespace {
@@ -55,11 +57,13 @@ class FaissFeatureDescriptorIndex : public FeatureDescriptorIndex {
 
 #pragma omp parallel num_threads(1)
     {
+#ifdef _OPENMP
       omp_set_num_threads(num_threads_);
 #ifdef _MSC_VER
       omp_set_nested(1);
 #else
       omp_set_max_active_levels(1);
+#endif
 #endif
 
       if (index_descriptors.data.rows() >= 512) {
@@ -128,11 +132,13 @@ class FaissFeatureDescriptorIndex : public FeatureDescriptorIndex {
 
 #pragma omp parallel num_threads(1)
     {
+#ifdef _OPENMP
       omp_set_num_threads(num_threads_);
 #ifdef _MSC_VER
       omp_set_nested(1);
 #else
       omp_set_max_active_levels(1);
+#endif
 #endif
 
       faiss::SearchParametersIVF search_params;

--- a/src/colmap/mvs/advancing_front_meshing.cc
+++ b/src/colmap/mvs/advancing_front_meshing.cc
@@ -757,8 +757,8 @@ colmap::PlyMesh ReconstructBlocks(
     }
 
     thread_pool.AddTask([&, block_idx]() {
-      // Disable OMP parallelism within each block task to avoid
-      // oversubscription since ThreadPool handles inter-block parallelism.
+    // Disable OMP parallelism within each block task to avoid
+    // oversubscription since ThreadPool handles inter-block parallelism.
 #ifdef _OPENMP
       omp_set_num_threads(1);
 #ifdef _MSC_VER

--- a/src/colmap/mvs/advancing_front_meshing.cc
+++ b/src/colmap/mvs/advancing_front_meshing.cc
@@ -69,7 +69,9 @@
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <boost/functional/hash.hpp>
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 namespace {
 
@@ -757,11 +759,13 @@ colmap::PlyMesh ReconstructBlocks(
     thread_pool.AddTask([&, block_idx]() {
       // Disable OMP parallelism within each block task to avoid
       // oversubscription since ThreadPool handles inter-block parallelism.
+#ifdef _OPENMP
       omp_set_num_threads(1);
 #ifdef _MSC_VER
       omp_set_nested(0);
 #else
       omp_set_max_active_levels(1);
+#endif
 #endif
 
       const auto& indices = block_point_indices[block_idx];
@@ -890,11 +894,13 @@ void AdvancingFrontMeshing(const AdvancingFrontMeshingOptions& options,
     }
 #pragma omp parallel num_threads(1)
     {
+#ifdef _OPENMP
       omp_set_num_threads(GetEffectiveNumThreads(options.num_threads));
 #ifdef _MSC_VER
       omp_set_nested(1);
 #else
       omp_set_max_active_levels(1);
+#endif
 #endif
       mesh = ReconstructBlock(ply_points, rays, options);
     }

--- a/src/colmap/retrieval/visual_index.cc
+++ b/src/colmap/retrieval/visual_index.cc
@@ -46,7 +46,9 @@
 #include <faiss/IndexIVF.h>
 #include <faiss/index_factory.h>
 #include <faiss/index_io.h>
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 namespace colmap {
 namespace retrieval {
@@ -71,11 +73,13 @@ std::unique_ptr<faiss::IndexIVF> BuildFaissIndex(
 
 #pragma omp parallel num_threads(1)
   {
+#ifdef _OPENMP
     omp_set_num_threads(GetEffectiveNumThreads(options.num_threads));
 #ifdef _MSC_VER
     omp_set_nested(1);
 #else
     omp_set_max_active_levels(1);
+#endif
 #endif
 
     index->train(visual_words.rows(), visual_words.data());
@@ -628,11 +632,13 @@ class FaissVisualIndex : public VisualIndex {
 
 #pragma omp parallel num_threads(1)
     {
+#ifdef _OPENMP
       omp_set_num_threads(GetEffectiveNumThreads(num_threads));
 #ifdef _MSC_VER
       omp_set_nested(1);
 #else
       omp_set_max_active_levels(1);
+#endif
 #endif
 
       index_->search(descriptors.rows(),


### PR DESCRIPTION
## Summary

When COLMAP is configured or compiled without OpenMP support (e.g. `-DOPENMP_ENABLED=OFF`, or on platforms like macOS using default Apple Clang without `libomp`), explicit calls to OpenMP runtime APIs (`omp_set_num_threads`, `omp_set_nested`, `omp_set_max_active_levels`) cause compilation or link errors because `<omp.h>` and its symbols are unavailable.

While `#pragma omp` directives are safely ignored by compilers when OpenMP is disabled, function calls into the OpenMP runtime library are not.

This PR guards `<omp.h>` inclusions and OpenMP runtime API calls behind `#ifdef _OPENMP` across:
- `controllers/pairing.cc`
- `feature/index.cc`
- `retrieval/visual_index.cc`
- `mvs/advancing_front_meshing.cc`

This brings these files into consistency with the rest of the codebase (e.g., `optim/ransac.h`, `optim/loransac.h`, and `mvs/texture_mapping.cc`).