### PR TITLE
Add missing standard and utility header includes

### DIFF
--- a/src/colmap/controllers/base_option_manager.h
+++ b/src/colmap/controllers/base_option_manager.h
@@ -31,6 +31,7 @@
 
 #include "colmap/util/hash_containers.h"
 #include "colmap/util/logging.h"
+#include "colmap/util/string.h"
 #include "colmap/util/types.h"
 
 #include <filesystem>

--- a/src/colmap/exe/gui.cc
+++ b/src/colmap/exe/gui.cc
@@ -33,6 +33,7 @@
 #include "colmap/ui/main_window.h"
 #endif
 #include "colmap/controllers/option_manager.h"
+#include "colmap/util/logging.h"
 
 namespace colmap {
 

--- a/src/colmap/util/threading.h
+++ b/src/colmap/util/threading.h
@@ -33,6 +33,7 @@
 #include "colmap/util/timer.h"
 
 #include <climits>
+#include <exception>
 #include <functional>
 #include <future>
 #include <list>


### PR DESCRIPTION
## Summary

Follow Include What You Use (IWYU) principles to add missing direct header inclusions:

- `src/colmap/util/threading.h`: Add `#include <exception>` for `std::exception`, `std::exception_ptr`, and `std::rethrow_exception` used in `AggregateException`. Prevents build failures on toolchains where `<future>` does not transitively include `<exception>` (such as LLVM libc++).
- `src/colmap/controllers/base_option_manager.h`: Add `#include "colmap/util/string.h"` for `StringPrintf` used in the inline template method `BaseOptionManager::AddDefaultOption`. Currently relies on an indirect include via `logging.h`.
- `src/colmap/exe/gui.cc`: Add `#include "colmap/util/logging.h"` for `LOG(ERROR)` when GUI support is disabled.