### PR TITLE
Fix member initialization order in GpuMatRefImage

### DIFF
--- a/src/colmap/mvs/gpu_mat_ref_image.cu
+++ b/src/colmap/mvs/gpu_mat_ref_image.cu
@@ -83,11 +83,11 @@ __global__ void FilterKernel(const cudaTextureObject_t image_texture,
 }  // namespace
 
 GpuMatRefImage::GpuMatRefImage(const size_t width, const size_t height)
-    : height_(height),
-      width_(width),
-      image(std::make_unique<GpuMat<uint8_t>>(width, height)),
+    : image(std::make_unique<GpuMat<uint8_t>>(width, height)),
       sum_image(std::make_unique<GpuMat<float>>(width, height)),
-      squared_sum_image(std::make_unique<GpuMat<float>>(width, height)) {}
+      squared_sum_image(std::make_unique<GpuMat<float>>(width, height)),
+      width_(width),
+      height_(height) {}
 
 void GpuMatRefImage::Filter(const uint8_t* image_data,
                             const size_t window_radius,


### PR DESCRIPTION
## Summary

In `GpuMatRefImage`, member variables are declared in `src/colmap/mvs/gpu_mat_ref_image.h` in the following order:
1. `image`
2. `sum_image`
3. `squared_sum_image`
4. `width_`
5. `height_`

However, the constructor initializer list in `src/colmap/mvs/gpu_mat_ref_image.cu` initialized `height_` and `width_` before the image buffers, and initialized `height_` before `width_`.

In C++, class members are always initialized in order of declaration. The mismatched initializer list triggers `-Wreorder-ctor` / `-Wreorder` compiler warnings (and errors when `-Werror` is enabled).

This PR reorders the constructor initializer list to match the class member declaration order.