### PR TITLE
Discard unused future return values in image undistorters

### DIFF
--- a/src/colmap/controllers/undistorters.cc
+++ b/src/colmap/controllers/undistorters.cc
@@ -365,7 +365,7 @@ void PMVSUndistorter::Run() {
     LOG(INFO) << StringPrintf(
         "Undistorting image [%d/%d]", i + 1, futures.size());
 
-    futures[i].get();
+    (void)futures[i].get();
   }
   if (stopped) {
     LOG(WARNING) << "Stopped image undistortion before writing the bundle and "
@@ -607,7 +607,7 @@ void CMPMVSUndistorter::Run() {
     LOG(INFO) << StringPrintf(
         "Undistorting image [%d/%d]", i + 1, futures.size());
 
-    futures[i].get();
+    (void)futures[i].get();
   }
 
   run_timer.PrintMinutes();
@@ -684,7 +684,7 @@ void StandaloneImageUndistorter::Run() {
     LOG(INFO) << StringPrintf(
         "Undistorting image [%d/%d]", i + 1, futures.size());
 
-    futures[i].get();
+    (void)futures[i].get();
   }
 
   run_timer.PrintMinutes();


### PR DESCRIPTION
## Summary

In `src/colmap/controllers/undistorters.cc`, worker threads in `PMVSUndistorter::Run()`, `CMPMVSUndistorter::Run()`, and `StandaloneImageUndistorter::Run()` return a `bool`, tracked via `std::vector<std::shared_future<bool>> futures`.

The completion loops wait on `futures[i].get();` without using the return value. On compilers with `-Wunused-result` or toolchains with `[[nodiscard]]` on future result getters, this triggers compiler warnings/errors.

This PR explicitly casts to `(void)futures[i].get();` to document that the return value is intentionally ignored while waiting for thread completion.