### PR TITLE
Add missing method chaining overrides to pycolmap classh_ext

### DIFF
--- a/src/pycolmap/pybind11_extension.h
+++ b/src/pycolmap/pybind11_extension.h
@@ -198,6 +198,54 @@ class classh_ext : public classh<type_, options...> {
     Parent::def_property(std::forward<Args>(args)...);
     return *this;
   }
+
+  template <typename... Args>
+  classh_ext& def_static(Args&&... args) {
+    Parent::def_static(std::forward<Args>(args)...);
+    return *this;
+  }
+
+  template <typename... Args>
+  classh_ext& def_property_readonly(Args&&... args) {
+    Parent::def_property_readonly(std::forward<Args>(args)...);
+    return *this;
+  }
+
+  template <typename... Args>
+  classh_ext& def_property_readonly_static(Args&&... args) {
+    Parent::def_property_readonly_static(std::forward<Args>(args)...);
+    return *this;
+  }
+
+  template <typename... Args>
+  classh_ext& def_property_static(Args&&... args) {
+    Parent::def_property_static(std::forward<Args>(args)...);
+    return *this;
+  }
+
+  template <typename... Args>
+  classh_ext& def_readonly(Args&&... args) {
+    Parent::def_readonly(std::forward<Args>(args)...);
+    return *this;
+  }
+
+  template <typename... Args>
+  classh_ext& def_readonly_static(Args&&... args) {
+    Parent::def_readonly_static(std::forward<Args>(args)...);
+    return *this;
+  }
+
+  template <typename... Args>
+  classh_ext& def_readwrite_static(Args&&... args) {
+    Parent::def_readwrite_static(std::forward<Args>(args)...);
+    return *this;
+  }
+
+  template <typename... Args>
+  classh_ext& def_buffer(Args&&... args) {
+    Parent::def_buffer(std::forward<Args>(args)...);
+    return *this;
+  }
 };
 
 }  // namespace PYBIND11_NAMESPACE


### PR DESCRIPTION
## Summary

`pycolmap::classh_ext` extends `py::classh` (pybind11 smart holder class wrapper) to provide custom reference semantics for `def_readwrite`.

Previously, only `def` and `def_property` were overridden to return `classh_ext&`. When other class-binding methods (such as `def_readonly`, `def_static`, `def_property_readonly`, `def_property_static`, `def_readwrite_static`, `def_buffer`) were called in a chain, they returned `Parent&` (`py::classh&`), which sliced the wrapper and prevented further chained calls to `classh_ext`-specific methods (such as `classh_ext::def_readwrite`).

This PR adds forwarding overrides returning `classh_ext&` for:
- `def_static`
- `def_property_readonly`
- `def_property_readonly_static`
- `def_property_static`
- `def_readonly`
- `def_readonly_static`
- `def_readwrite_static`
- `def_buffer`