### PR TITLE
Keep at least one panorama rendering worker

### DIFF
--- a/python/pycolmap/panorama.py
+++ b/python/pycolmap/panorama.py
@@ -482,7 +482,7 @@ def render_perspective_images(
     )
 
     num_panos = len(pano_image_names)
-    max_workers = min(32, (os.cpu_count() or 2) - 1)
+    max_workers = max(1, min(32, (os.cpu_count() or 2) - 1))
 
     pbar = None
     if show_progress:

--- a/python/pycolmap/panorama_test.py
+++ b/python/pycolmap/panorama_test.py
@@ -1,12 +1,16 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import pycolmap
 
 from .panorama import (
+    PanoProcessor,
+    PanoRenderOptions,
     filter_database_by_covisibility,
     get_virtual_rotations,
+    render_perspective_images,
 )
 
 
@@ -31,6 +35,37 @@ def test_get_virtual_rotations() -> None:
     for rotation in rotations:
         np.testing.assert_allclose(rotation @ rotation.T, np.eye(3), atol=1e-15)
         np.testing.assert_allclose(np.linalg.det(rotation), 1.0, atol=1e-15)
+
+
+@pytest.mark.parametrize("cpu_count", [1, None, 4, 64])
+def test_render_perspective_images_cpu_count(
+    cpu_count: int | None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("pycolmap.panorama.os.cpu_count", lambda: cpu_count)
+    processed_names: list[str] = []
+
+    def process(self: PanoProcessor, pano_name: str) -> None:
+        processed_names.append(pano_name)
+
+    # Keep the real executor without optional image-processing dependencies.
+    monkeypatch.setattr(PanoProcessor, "process", process)
+    image_names = ["pano1.jpg", "pano2.jpg", "pano3.jpg"]
+    processor = render_perspective_images(
+        image_names,
+        tmp_path / "input",
+        tmp_path / "output",
+        tmp_path / "masks",
+        PanoRenderOptions(
+            num_steps_yaw=1,
+            pitches_deg=(0.0,),
+            hfov_deg=90.0,
+            vfov_deg=90.0,
+        ),
+        show_progress=False,
+    )
+
+    assert isinstance(processor, PanoProcessor)
+    assert sorted(processed_names) == image_names
 
 
 def test_filter_database_by_covisibility(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

When `os.cpu_count()` returns 1, panorama perspective rendering subtracts one reserved CPU and passes `max_workers=0` to `ThreadPoolExecutor`. This raises `ValueError: max_workers must be greater than 0` before any panorama is processed.

Keep at least one rendering worker. The existing unknown-CPU fallback, reservation of one CPU on multicore hosts, and 32-worker cap remain unchanged.

Add a regression test for reported CPU counts of 1, `None`, 4, and 64. It uses the real executor and verifies that every submitted panorama is processed, replacing only the image-processing work to avoid optional dependencies.

## Validation

- Before the fix: the single-CPU regression raises the reported exception; the three comparison cases pass.
- After the fix: all six tests in `python/pycolmap/panorama_test.py` pass.
- A separate smoke test exercised actual rendering with `cpu_count=1`, two synthetic 16x8 panoramas, Pillow/OpenCV, and the native PyCOLMAP bitmap writer. It produced two rendered images and two masks, all 4x4.
- Ruff check, Ruff format check, and `git diff --check` pass.

The Python tests used this checkout's source with the native PyCOLMAP 4.2.0 Windows wheel (Python 3.13.5). COLMAP's C++ code and the full reconstruction pipeline were not built or tested.

AI assistance: OpenAI Codex identified the edge case, implemented the fix, and ran the regression tests.
