### PR TITLE
Cover def_cast in pycolmap classh_ext chaining overrides

### DIFF
--- a/src/pycolmap/pybind11_extension.h
+++ b/src/pycolmap/pybind11_extension.h
@@ -246,6 +246,12 @@ class classh_ext : public classh<type_, options...> {
     Parent::def_buffer(std::forward<Args>(args)...);
     return *this;
   }
+
+  template <typename... Args>
+  classh_ext& def_cast(Args&&... args) {
+    Parent::def_cast(std::forward<Args>(args)...);
+    return *this;
+  }
 };
 
 }  // namespace PYBIND11_NAMESPACE


### PR DESCRIPTION
Follow-up to #4710 (review nit from @B1ueber2y).

`def_cast` is the only remaining `py::class_`-chaining method without a `classh_ext` override returning `classh_ext&`. If used in a chain, it would return `Parent&` and slice the wrapper, preventing further chained calls to `classh_ext`-specific methods (e.g. the custom `def_readwrite`).

This adds the same forwarding override as the other methods. No binding currently calls `def_cast`, so this is purely future-proofing.

Verified: standalone compile-only chaining proof (`static_assert` on the `def_cast` return type) fails on the pre-fix header and passes with the fix; one real binding TU (`geometry/rigid3.cc`) recompiles cleanly; `scripts/format/c++.sh` clean.