### PR TITLE
Update copyright notice to credit The COLMAP Contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,8 @@ refers only to the license for COLMAP itself, independent of its dependencies,
 which are separately licensed. Building COLMAP with these dependencies may
 affect the resulting COLMAP license.
 
-    Copyright (c), ETH Zurich and UNC Chapel Hill.
+    Copyright (c) 2016, ETH Zurich and UNC Chapel Hill.
+    Copyright (c) 2016-2026, The COLMAP Contributors.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ refers only to the license for COLMAP itself, independent of its thirdparty
 dependencies, which are separately licensed. Building COLMAP with these
 dependencies may affect the resulting COLMAP license.
 
-    Copyright (c), ETH Zurich and UNC Chapel Hill.
+    Copyright (c) 2016, ETH Zurich and UNC Chapel Hill.
+    Copyright (c) 2016-2026, The COLMAP Contributors.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/doc/license.rst
+++ b/doc/license.rst
@@ -8,7 +8,8 @@ dependencies may affect the resulting COLMAP license.
 
 .. code-block:: text
 
-    Copyright (c), ETH Zurich and UNC Chapel Hill.
+    Copyright (c) 2016, ETH Zurich and UNC Chapel Hill.
+    Copyright (c) 2016-2026, The COLMAP Contributors.
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Stacked on #4713 (PR 2/3, followed by #4716).

List ETH Zurich and UNC Chapel Hill as the 2016 copyright holders and The COLMAP Contributors for 2016-2026 in LICENSE, README.md, and doc/license.rst.